### PR TITLE
Auto-Deploy to Shinyapps.io

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -1,0 +1,35 @@
+
+name: PR
+
+# Run on all pull requests
+on:
+  pull_request: {}
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: Ubuntu-20.04
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Build image
+      - name: Build image
+        run: docker build -t pullrequestimage . 
+      # run the image (but supply the TESTNAME in stead of MASTERNAME, so the 
+      # app ends up in a different place.   
+      - name: execute
+        run: >
+          docker run 
+          -e SHINY_ACC_NAME=${{secrets.SHINY_ACC_NAME}} 
+          -e TOKEN=${{secrets.TOKEN}} 
+          -e SECRET=${{secrets.SECRET}} 
+          -e MASTERNAME=${{secrets.TEST_NAME}} 
+          pullrequestimage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,38 @@
+
+name: Run on push master, main
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main, master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: Ubuntu-20.04
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # build the docker image and give it the name main
+      - name: Build image
+        run: docker build -t main . 
+      # run the docker image supply the secrets from the github secrets store.  
+      - name: execute
+        run: >
+          docker run 
+          -e SHINY_ACC_NAME=${{ secrets.SHINY_ACC_NAME }} 
+          -e TOKEN=${{secrets.TOKEN}} 
+          -e SECRET=${{secrets.SECRET}} 
+          -e MASTERNAME=${{secrets.MASTER_NAME}} 
+          main
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM rocker/shiny:4.0.4
-RUN install2.r rsconnect
+RUN install2.r rsconnect shiny here leaflet plotly tidyverse sf
 WORKDIR /home/shinyusr
 COPY app/ /home/shinyusr/app/
 COPY deploy.R deploy.R

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rocker/shiny:4.0.4
 RUN install2.r rsconnect
 WORKDIR /home/shinyusr
-COPY /app/ /app/
+COPY app/ /home/shinyusr/app/
 COPY deploy.R deploy.R
 CMD Rscript deploy.R

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM rocker/shiny:4.0.4
+RUN install2.r rsconnect
+WORKDIR /home/shinyusr
+COPY /app/ /app/
+COPY deploy.R deploy.R
+CMD Rscript deploy.R

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Examining Housing Choice Voucher (Section 8) in Delaware
-This repo contains all scripts and documentation related to out exploratory work on Housing Choice Voucher (Section 8) assistance eligibility across Delaware. 
+This repo contains all scripts and documentation related to out exploratory work on Housing Choice Voucher (Section 8) assistance eligibility across Delaware.
 
+## App
+
+The development version of the app is available at: https://nami-techimpact.shinyapps.io/housing-voucher/
+
+Each pull request will be deployed at:
+https://nami-techimpact.shinyapps.io/housing-voucher-test
 
 ## Project Structure
 

--- a/deploy.R
+++ b/deploy.R
@@ -1,0 +1,20 @@
+library(rsconnect)
+# a function to stop the script when one of the variables cannot be found. and to strip quotation marks from the secrets when you supplied them. (maybe it is just easier to never use them)
+error_on_missing_name <- function(name){
+    var <- Sys.getenv(name, unset=NA)
+    if(is.na(var)){
+        stop(paste0("cannot find ",name, " !"),call. = FALSE)
+    }
+    gsub("\"", '',var)
+}
+# Authenticate
+setAccountInfo(name = error_on_missing_name("SHINY_ACC_NAME"),
+               token = error_on_missing_name("TOKEN"),
+               secret = error_on_missing_name("SECRET"))
+# Deploy the application.
+deployApp(
+    appDir = "app",
+    appFiles = NULL, # deploy everything in the app folder
+    appName = error_on_missing_name("MASTERNAME"),
+    appTitle = "shinyapplication")
+


### PR DESCRIPTION
This PR adds functionality to automatically deploy to shinyapps.io for each pull request and merge to main. (Thanks to [this blog post](https://www.r-bloggers.com/2021/02/deploy-to-shinyapps-io-from-github-actions/).)

The environmental variables are set so that the app will be pushed into to my shiny app account (`nami-techimpact`) for now.

Fixes #14 