### PR TITLE
Add the page for advocates (+ UI tweaks)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM rocker/shiny-verse
-RUN install2.r rsconnect here leaflet plotly sf
+RUN install2.r rsconnect here leaflet plotly sf shinyWidgets
 WORKDIR /home/shinyusr
 COPY app/ /home/shinyusr/app/
 COPY deploy.R deploy.R

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM rocker/shiny-verse
-RUN install2.r rsconnect here leaflet plotly sf shinyWidgets
+RUN install2.r rsconnect leaflet plotly sf shinyWidgets
 WORKDIR /home/shinyusr
 COPY app/ /home/shinyusr/app/
 COPY deploy.R deploy.R

--- a/app/advocates_panel.r
+++ b/app/advocates_panel.r
@@ -1,10 +1,12 @@
 # Advocates Tab Panel
+library(shinyWidgets)
+
 advocates_panel <- tabPanel(
     "For Advocates",
     tags$div(class = "main-point",
              "Find Out How Your Neighbohood is Doing"),
     tags$div(class = "center-container",
-             textInput("geoid", "GEOID")),
+             uiOutput("GEOID_selector")),
     tags$div(class = "main-point",
              "(Vizualization on per census tract)")
 )

--- a/app/advocates_panel.r
+++ b/app/advocates_panel.r
@@ -1,0 +1,10 @@
+# Advocates Tab Panel
+advocates_panel <- tabPanel(
+    "For Advocates",
+    tags$div(class = "main-point",
+             "Find Out How Your Neighbohood is Doing"),
+    tags$div(class = "center-container",
+             textInput("geoid", "GEOID")),
+    tags$div(class = "main-point",
+             "(Vizualization on per census tract)")
+)

--- a/app/home_panel.r
+++ b/app/home_panel.r
@@ -1,0 +1,30 @@
+# homepage
+home_panel <- tabPanel("Home",
+                       tags$div(class = "main-point",
+                                textOutput("main_text")),
+                       plotlyOutput("mainplot"),
+                       tags$div(class = "select-county",
+                                # Sidebar with a slider input for number of bins
+                                selectInput("selectedCounty", 
+                                            label = "Explore more by selecting a county:",
+                                            choices = c("(All Delaware)" = "all",
+                                                        "New Castle" = "003",
+                                                        "Kent" = "001",
+                                                        "Sussex" = "005"))
+                       ),
+                       tags$div(class = "main-point",
+                                "Do you think that's ok?"),
+                       tags$div(class = "take-action-container",
+                                tags$div(class = "take-action-card",
+                                         tags$div(class = "call-to-action-text", 
+                                                  "Here are some ways you can take action now"),
+                                         tags$ul(class = "follow-campaign-list",
+                                                 tags$li("Follow", tags$a("H.O.M.E.S. Campaign", href="https://www.homescampaignde.org/")),
+                                                 tags$li("Send a letter to your local representative to support housing reform bills",
+                                                         tags$a("(Template by H.O.M.E.S.)", 
+                                                                href = "https://613b7d3b-0baa-4963-a0d2-2c365bc54f9e.filesusr.com/ugd/7148e3_2400e00b6b70477899b65e347060fdd6.docx?dn=Sample%20Letter%20for%20Bill%20of%20Rights%20for%20Individuals%20Experiencing%20Homelessness%20.docx"),
+                                                 )
+                                         ),
+                                )
+                       )
+)

--- a/app/home_panel.r
+++ b/app/home_panel.r
@@ -1,30 +1,32 @@
 # homepage
-home_panel <- tabPanel("Home",
-                       tags$div(class = "main-point",
-                                textOutput("main_text")),
-                       plotlyOutput("mainplot"),
-                       tags$div(class = "select-county",
-                                # Sidebar with a slider input for number of bins
-                                selectInput("selectedCounty", 
-                                            label = "Explore more by selecting a county:",
-                                            choices = c("(All Delaware)" = "all",
-                                                        "New Castle" = "003",
-                                                        "Kent" = "001",
-                                                        "Sussex" = "005"))
-                       ),
-                       tags$div(class = "main-point",
-                                "Do you think that's ok?"),
-                       tags$div(class = "take-action-container",
-                                tags$div(class = "take-action-card",
-                                         tags$div(class = "call-to-action-text", 
-                                                  "Here are some ways you can take action now"),
-                                         tags$ul(class = "follow-campaign-list",
-                                                 tags$li("Follow", tags$a("H.O.M.E.S. Campaign", href="https://www.homescampaignde.org/")),
-                                                 tags$li("Send a letter to your local representative to support housing reform bills",
-                                                         tags$a("(Template by H.O.M.E.S.)", 
-                                                                href = "https://613b7d3b-0baa-4963-a0d2-2c365bc54f9e.filesusr.com/ugd/7148e3_2400e00b6b70477899b65e347060fdd6.docx?dn=Sample%20Letter%20for%20Bill%20of%20Rights%20for%20Individuals%20Experiencing%20Homelessness%20.docx"),
-                                                 )
-                                         ),
-                                )
-                       )
+library(shinyWidgets)
+home_panel <- tabPanel(
+    "Home",
+    tags$div(class = "main-point",
+             textOutput("main_text")),
+    plotlyOutput("mainplot"),
+    tags$div(class = "select-county",
+             # Sidebar with a slider input for number of bins
+             radioGroupButtons("selectedCounty", 
+                          label = "Explore more by selecting a county:",
+                          choices = c("(All Delaware)" = "all",
+                                      "New Castle" = "003",
+                                      "Kent" = "001",
+                                      "Sussex" = "005"))
+    ),
+    tags$div(class = "main-point",
+             "Do you think that's ok?"),
+    tags$div(class = "take-action-container",
+             tags$div(class = "take-action-card",
+                      tags$div(class = "call-to-action-text", 
+                               "Here are some ways you can take action now"),
+                      tags$ul(class = "follow-campaign-list",
+                              tags$li("Follow", tags$a("H.O.M.E.S. Campaign", href="https://www.homescampaignde.org/")),
+                              tags$li("Send a letter to your local representative to support housing reform bills",
+                                      tags$a("(Template by H.O.M.E.S.)", 
+                                             href = "https://613b7d3b-0baa-4963-a0d2-2c365bc54f9e.filesusr.com/ugd/7148e3_2400e00b6b70477899b65e347060fdd6.docx?dn=Sample%20Letter%20for%20Bill%20of%20Rights%20for%20Individuals%20Experiencing%20Homelessness%20.docx"),
+                              )
+                      ),
+             )
+    )
 )

--- a/app/server.R
+++ b/app/server.R
@@ -8,7 +8,6 @@
 #
 
 library(shiny)
-library(here)
 library(tidyverse)
 library(plotly)
 library(sf)

--- a/app/server.R
+++ b/app/server.R
@@ -1,12 +1,3 @@
-#
-# This is the server logic of a Shiny web application. You can run the
-# application by clicking 'Run App' above.
-#
-# Find out more about building applications with Shiny here:
-#
-#    http://shiny.rstudio.com/
-#
-
 library(shiny)
 library(tidyverse)
 library(plotly)

--- a/app/server.R
+++ b/app/server.R
@@ -113,4 +113,9 @@ shinyServer(function(input, output) {
                "% of the families needing Housing Choice Voucher are receiving it")
     )
     
+    output$GEOID_selector <- renderUI({
+        multiInput("GEOID_selector", "Choose GEOIDs",
+                   choices = geo_data$GEOID)
+    })
+    
 })

--- a/app/ui.R
+++ b/app/ui.R
@@ -1,11 +1,10 @@
 library(shiny)
 library(leaflet)
 library(plotly)
-library(here)
 
 # Load tab-panels
-source(here("app/home_panel.r"))
-source(here("app/advocates_panel.r"))
+source("home_panel.r")
+source("advocates_panel.r")
 
 navbarPage(
     "Housing Choice Voucher in Delaware",

--- a/app/ui.R
+++ b/app/ui.R
@@ -1,12 +1,3 @@
-#
-# This is the user-interface definition of a Shiny web application. You can
-# run the application by clicking 'Run App' above.
-#
-# Find out more about building applications with Shiny here:
-#
-#    http://shiny.rstudio.com/
-#
-
 library(shiny)
 library(leaflet)
 library(plotly)

--- a/app/ui.R
+++ b/app/ui.R
@@ -12,7 +12,9 @@ library(leaflet)
 library(plotly)
 library(here)
 
+# Load tab-panels
 source(here("app/home_panel.r"))
+source(here("app/advocates_panel.r"))
 
 navbarPage(
     "Housing Choice Voucher in Delaware",
@@ -20,6 +22,7 @@ navbarPage(
         tags$link(rel = "stylesheet", type = "text/css", href = "style.css")
     ),
     home_panel, # Add a tab panel for home
+    advocates_panel,
     tabPanel("Details",
              leafletOutput("map"),
              "We defined renters potentially eligible for housing vouchers by calculating renter households paying 30% or more income on rent."

--- a/app/ui.R
+++ b/app/ui.R
@@ -13,12 +13,13 @@ library(plotly)
 
 
 
-shinyUI(navbarPage(
+navbarPage(
     "Housing Choice Voucher in Delaware",
-    tags$head(
+    header = tags$head(
         tags$link(rel = "stylesheet", type = "text/css", href = "style.css")
     ),
     tabPanel("Home",
+             
              tags$div(class = "main-point",
                       textOutput("main_text")),
              plotlyOutput("mainplot"),
@@ -53,5 +54,5 @@ shinyUI(navbarPage(
     ),
     footer = tags$div(class = "footer",
                       includeHTML("footer.html"))
-))
+)
 

--- a/app/ui.R
+++ b/app/ui.R
@@ -10,44 +10,16 @@
 library(shiny)
 library(leaflet)
 library(plotly)
+library(here)
 
-
+source(here("app/home_panel.r"))
 
 navbarPage(
     "Housing Choice Voucher in Delaware",
     header = tags$head(
         tags$link(rel = "stylesheet", type = "text/css", href = "style.css")
     ),
-    tabPanel("Home",
-             
-             tags$div(class = "main-point",
-                      textOutput("main_text")),
-             plotlyOutput("mainplot"),
-             tags$div(class = "select-county",
-                      # Sidebar with a slider input for number of bins
-                      selectInput("selectedCounty", 
-                                  label = "Explore more by selecting a county:",
-                                  choices = c("(All Delaware)" = "all",
-                                              "New Castle" = "003",
-                                              "Kent" = "001",
-                                              "Sussex" = "005"))
-             ),
-             tags$div(class = "main-point",
-                      "Do you think that's ok?"),
-             tags$div(class = "take-action-container",
-                      tags$div(class = "take-action-card",
-                               tags$div(class = "call-to-action-text", 
-                                        "Here are some ways you can take action now"),
-                               tags$ul(class = "follow-campaign-list",
-                                       tags$li("Follow", tags$a("H.O.M.E.S. Campaign", href="https://www.homescampaignde.org/")),
-                                       tags$li("Send a letter to your local representative to support housing reform bills",
-                                               tags$a("(Template by H.O.M.E.S.)", 
-                                                      href = "https://613b7d3b-0baa-4963-a0d2-2c365bc54f9e.filesusr.com/ugd/7148e3_2400e00b6b70477899b65e347060fdd6.docx?dn=Sample%20Letter%20for%20Bill%20of%20Rights%20for%20Individuals%20Experiencing%20Homelessness%20.docx"),
-                                       )
-                               ),
-                      )
-             )
-    ),
+    home_panel, # Add a tab panel for home
     tabPanel("Details",
              leafletOutput("map"),
              "We defined renters potentially eligible for housing vouchers by calculating renter households paying 30% or more income on rent."

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -15,6 +15,11 @@
     justify-content: center;
 }
 
+.center-container {
+    display: flex;
+    justify-content: center;
+}
+
 .take-action-container {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
This PR adds a page for advocates. We are testing out a page that local organizers can use to find out the information about the housing voucher. I included a multi-input selector for GEOIDs.

This PR also includes a tweak for the radio button on the Home page. The radio button is rendered as a normal button, via the `shinyWidgets` package. This improves the experience for mobile users (fixes #28).

I also separated different panels into different files---so that tracking changes later will be easier.