### PR TITLE
Add headings and placeholders for the advocates and by-county comparison tabs

### DIFF
--- a/app/advocates_panel.r
+++ b/app/advocates_panel.r
@@ -8,5 +8,10 @@ advocates_panel <- tabPanel(
     tags$div(class = "center-container",
              uiOutput("GEOID_selector")),
     tags$div(class = "main-point",
-             "(Vizualization on per census tract)")
+             "In the selected X census tracts, only XX% of the families
+             needing Housing Vouche Voucher are receiving it."),
+    tags$div(class = "comment",
+             "(*Add a pie chart for the overview? receiving vs not receiving)"),
+    tags$div(class = "comment",
+             "(*Add the table showing reported & eligible households)")
 )

--- a/app/counties_panel.R
+++ b/app/counties_panel.R
@@ -1,0 +1,18 @@
+# Counties Panel
+
+
+counties_panel <- tabPanel(
+    "By County",
+    tags$div(class = "main-point",
+             "Families in the New Castle County are 
+             most likely to receive a voucher"),
+    tags$div(class = "comment",
+             "(*Add Visual: Number of households spending above 30% and 50%
+             of hh_income on rent.)"),
+    tags$div(class = "main-point",
+             "Families in Sussex County may be facing the most difficulty
+             getting Housing Choice Voucher"),
+    tags$div(class = "comment",
+             "(*Add visual: # Proportion of households spending above 
+             30% and 50% of hh_income on rent and not receiving assitance.")
+)

--- a/app/methods_panel.R
+++ b/app/methods_panel.R
@@ -1,0 +1,12 @@
+# Methods Panel
+
+methods_panel <- tabPanel(
+    "Methods",
+    tags$div(class = "methods-container",
+             tags$h1("Methodology"),
+             tags$p("We defined households potentially eligible for housing vouchers by 
+             calculating renter households paying 30% or more income on rent. We
+             also excluded households with gross income exceeding $100,000.")
+    )
+)
+

--- a/app/ui.R
+++ b/app/ui.R
@@ -5,6 +5,8 @@ library(plotly)
 # Load tab-panels
 source("home_panel.r")
 source("advocates_panel.r")
+source("counties_panel.R")
+source("methods_panel.R")
 
 navbarPage(
     "Housing Choice Voucher in Delaware",
@@ -12,14 +14,9 @@ navbarPage(
         tags$link(rel = "stylesheet", type = "text/css", href = "style.css")
     ),
     home_panel, # Add a tab panel for home
+    counties_panel,
     advocates_panel,
-    tabPanel("Details",
-             leafletOutput("map"),
-             tags$h1("Methodology"),
-             "We defined households potentially eligible for housing vouchers by 
-             calculating renter households paying 30% or more income on rent. We
-             also excluded households with gross income exceeding $100,000."
-    ),
+    methods_panel,
     footer = tags$div(class = "footer",
                       includeHTML("footer.html"))
 )

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -10,6 +10,17 @@
     max-width: 15em;
 }
 
+.comment {
+    text-align: center;
+    color: gray;
+    font-size: 2rem;
+    margin-top: 10rem;
+    margin-bottom: 10rem;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 15em;
+}
+
 .select-county {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
This PR adds headings and placeholders for the tabs for the advocates and the by-county comparisons.

@mehak25 : I indicated the places for visualizations in the text (e.g., `(*Add a pie chart for the overview? receiving vs not receiving)`). Can you take a look at the test app and go to tabs `For Advocates` and `By County` (after deployment)?
https://nami-techimpact.shinyapps.io/housing-voucher-test/
Feel free to merge the pull request if you think that's ok. 