### PR TITLE
Set a max-width for plots and revise labels for the buttons

### DIFF
--- a/app/counties_panel.R
+++ b/app/counties_panel.R
@@ -7,24 +7,22 @@ counties_panel <- tabPanel(
              "Families in the New Castle County are 
              most likely to receive a voucher"),
     plotlyOutput("number_county"),
-    tags$div(class = "select-number",
-             # Sidebar with a slider input for number of bins
+    tags$div(class = "select-threshold",
              radioGroupButtons("selectedNumber", 
-                               label = "What about the number of households spending above 50% of household income on rent ?",
-                               choices = c("Households spending above 50%" = "50",
-                                           "Households spending above 30%" = "30"),
+                               label = "Focusing on households with rent spending above:",
+                               choices = c("30%+" = "30",
+                                           "50%+" = "50"),
                                selected='30')
     ),
     tags$div(class = "main-point",
              "Families in Sussex County may be facing the most difficulty
              getting Housing Choice Voucher"),
     plotlyOutput("prop_county"),
-    tags$div(class = "select-prop",
-             # Sidebar with a slider input for number of bins
+    tags$div(class = "select-threshold",
              radioGroupButtons("selectedProp", 
-                               label = "What about the number of households spending above 50% of household income on rent ?",
-                               choices = c("Households spending above 50%" = "50",
-                                           "Households spending above 30%" = "30"),
+                               label = "Focusing on households with rent spending above:",
+                               choices = c("30%+" = "30",
+                                           "50%+" = "50"),
                                selected='30')
     )
 )

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -1,3 +1,9 @@
+.tab-pane {
+    max-width: 1024px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
 
 /* Main Message */
 .main-point {

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -111,3 +111,9 @@
 .footer-container {
     margin: 2rem;
 }
+
+.select-threshold {
+    text-align: center;
+    display: flex;
+    justify-content: center;
+}


### PR DESCRIPTION
This PR sets a max-width for plots so that the plots will show up normally in a widescreen display.

It also shortens the labels for the threshold selector for rent:

![image](https://user-images.githubusercontent.com/17035406/152834050-6e2a9fb7-ec0b-4344-832d-8f6ce6501edb.png)
