### PR TITLE
Fix typos & make bar plots horizontal

### DIFF
--- a/app/Scripts/county.R
+++ b/app/Scripts/county.R
@@ -25,10 +25,10 @@ data_county <- geo_data_nogeometry %>%
 
 # Number of households spending above 30% and 50% of hh_income on rent.
 number_county_common_elements <- list(
-    geom_bar(aes(fill=Category),
-             stat="identity",
-             colour="black",
-             position=position_dodge()),
+    geom_bar(aes(fill = Category),
+             stat = "identity",
+             colour = "black",
+             position = position_dodge()),
     ylab("Number of households"),
     xlab("County")
 )
@@ -55,23 +55,23 @@ number_county_50 <- data_county %>%
 
 # Proportion of households spending above 30% and 50% of hh_income on rent and not receiving assitance.
 prop_county_common_elements <- list(
-    geom_bar(aes(fill=Category),
-             stat="identity",
-             position=position_dodge(),
+    geom_bar(aes(fill = Category),
+             stat = "identity",
+             position = position_dodge(),
              width = 0.6),
     scale_y_continuous(labels = scales::percent,
                        limits = c(0, 1)),
     ylab(""),
     xlab(""),
     theme_minimal(),
-    theme(legend.position="none"),
+    theme(legend.position = "none"),
     coord_flip(),
     ggtitle("Potentialy-Eligible Households Not Receiving Voucher")
 )
 
 prop_county_30 <- data_county %>% 
-    mutate(rent_above30=(rent_above30-reported_HUD)/rent_above30) %>%
-    select(county,rent_above30) %>%
+    mutate(rent_above30 = (rent_above30 - reported_HUD) / rent_above30) %>%
+    select(county, rent_above30) %>%
     dplyr::rename(
         'Households spending 30%+ income on rent' = rent_above30) %>%
     gather(Category, count, -c(county)) %>%
@@ -79,7 +79,7 @@ prop_county_30 <- data_county %>%
     prop_county_common_elements
 
 prop_county_50 <- data_county %>%
-    mutate(rent_above50=(rent_above50-reported_HUD)/rent_above50) %>%
+    mutate(rent_above50 = (rent_above50 - reported_HUD) / rent_above50) %>%
     select(county,rent_above50) %>%
     dplyr::rename(
         'Households spending 50%+ income on rent' = rent_above50

--- a/app/Scripts/county.R
+++ b/app/Scripts/county.R
@@ -3,95 +3,89 @@ library(tidyverse)
 library(plotly)
 library(sf)
 
-
 # Load Data
 acs_hud_de_geojoined <- read_rds("acs_hud_de_geojoined.rds")
 geo_data <- acs_hud_de_geojoined
 geo_data_nogeometry <- geo_data %>% 
-  st_drop_geometry()
-
-
+    st_drop_geometry()
 
 data_county <- geo_data_nogeometry %>%
-  filter(number_reported > 0) %>%
-  mutate(county = substr(GEOID, 3, 5)) %>%
-  mutate(county=replace(county, county=='001', 'Kent')) %>%
-  mutate(county=replace(county, county=='003', 'New Castle')) %>%
-  mutate(county=replace(county, county=='005', 'Sussex'))  %>%
-  rowwise() %>% 
-  mutate(above30 = sum(rent_30E, rent_35E, rent_40E,rent_50E),
-         above50 = rent_50E) %>%
-  group_by(county) %>%
-  summarize(reported_HUD = sum(number_reported),
-            rent_above30 = sum(above30),
-            rent_above50 = sum(above50)) 
+    filter(number_reported > 0) %>%
+    mutate(county = substr(GEOID, 3, 5)) %>%
+    mutate(county=replace(county, county=='001', 'Kent')) %>%
+    mutate(county=replace(county, county=='003', 'New Castle')) %>%
+    mutate(county=replace(county, county=='005', 'Sussex'))  %>%
+    rowwise() %>% 
+    mutate(above30 = sum(rent_30E, rent_35E, rent_40E,rent_50E),
+           above50 = rent_50E) %>%
+    group_by(county) %>%
+    summarize(reported_HUD = sum(number_reported),
+              rent_above30 = sum(above30),
+              rent_above50 = sum(above50)) 
 
 # Number of households spending above 30% and 50% of hh_income on rent.
-number_county_30 = data_county %>%  select(reported_HUD,rent_above30,county) %>%
-  dplyr::rename(
-    'Household applied for Section 8 assisstance'=reported_HUD,
-    'Household spending above 30% of income on rent'=rent_above30) %>%
-  gather(Category, count, -c(county)) %>%
-  ## na.rm = TRUE ensures all values are NA are taken as 0
-  ggplot(aes(x=county,y=count))+
-  geom_bar(aes(fill=Category),   # fill depends on cond2
-           stat="identity",
-           colour="black",    # Black outline for all
-           position=position_dodge())+
-  ylab("Number of households")+
-  xlab("County")+
-  labs(color = "Percentage of hh_income spent on rent")+
-  ggtitle("Number of households soending above 30% of household income on rent")
+number_county_common_elements <- list(
+    geom_bar(aes(fill=Category),
+             stat="identity",
+             colour="black",
+             position=position_dodge()),
+    ylab("Number of households"),
+    xlab("County")
+)
 
-number_county_50 = data_county %>%  select(reported_HUD,rent_above50,county) %>%
-  dplyr::rename(
-    'Household applied for Section 8 assisstance'=reported_HUD,
-    'Household spending above 50% of income on rent'=rent_above50) %>%
-  gather(Category, count, -c(county)) %>%
-  ## na.rm = TRUE ensures all values are NA are taken as 0
-  ggplot(aes(x=county,y=count))+
-  geom_bar(aes(fill=Category),   # fill depends on cond2
-           stat="identity",
-           colour="black",    # Black outline for all
-           position=position_dodge())+
-  ylab("Number of households")+
-  xlab("County")+
-  labs(color = "Percentage of hh_income spent on rent")+
-  ggtitle("Number of households soending above 50% of household income on rent")
+number_county_30 <- data_county %>%  
+    select(reported_HUD, rent_above30, county) %>%
+    dplyr::rename(
+        'Receiving Voucher' = reported_HUD,
+        'Spending 30%+ income on rent' = rent_above30) %>%
+    gather(Category, count, -c(county)) %>%
+    ggplot(aes(x = county, y = count)) + 
+    number_county_common_elements +
+    ggtitle("Households Spending 30%+ Income on Rent")
+
+number_county_50 <- data_county %>% 
+    select(reported_HUD, rent_above50, county) %>%
+    dplyr::rename(
+        'Receiving Voucher' = reported_HUD,
+        'Spending 50%+ income on rent' = rent_above50) %>%
+    gather(Category, count, -c(county)) %>%
+    ggplot(aes(x = county, y = count))+
+    number_county_common_elements +
+    ggtitle("Households Spending 50%+ Income on Rent")
 
 # Proportion of households spending above 30% and 50% of hh_income on rent and not receiving assitance.
-prop_county_30 = data_county %>% mutate(rent_above30=(rent_above30-reported_HUD)/rent_above30) %>%
-  select(county,rent_above30) %>%
-  dplyr::rename(
-    'Households spending above 30% of income on rent'=rent_above30) %>%
-  gather(Category, count, -c(county)) %>%
-  ## na.rm = TRUE ensures all values are NA are taken as 0
-  ggplot(aes(x=county,y=count))+
-  geom_bar(aes(fill=Category),   # fill depends on cond2
-           stat="identity",
-           colour="black",    # Black outline for all
-           position=position_dodge())+
-  ylab("Proportion of households NOT receiving assistance")+
-  xlab("County")+
-  labs(color = "Percentage of hh_income spent on rent")+
-  theme(legend.position="top") +
-  ggtitle("")
+prop_county_common_elements <- list(
+    geom_bar(aes(fill=Category),
+             stat="identity",
+             position=position_dodge(),
+             width = 0.6),
+    scale_y_continuous(labels = scales::percent,
+                       limits = c(0, 1)),
+    ylab(""),
+    xlab(""),
+    theme_minimal(),
+    theme(legend.position="none"),
+    coord_flip(),
+    ggtitle("Potentialy-Eligible Households Not Receiving Voucher")
+)
 
+prop_county_30 <- data_county %>% 
+    mutate(rent_above30=(rent_above30-reported_HUD)/rent_above30) %>%
+    select(county,rent_above30) %>%
+    dplyr::rename(
+        'Households spending 30%+ income on rent' = rent_above30) %>%
+    gather(Category, count, -c(county)) %>%
+    ggplot(aes(x = county, y = count)) + 
+    prop_county_common_elements
 
-prop_county_50 = data_county %>% mutate(rent_above50=(rent_above50-reported_HUD)/rent_above50) %>%
-  select(county,rent_above50) %>%
-  dplyr::rename(
-    'Households spending above 50% of income on ren'=rent_above50
-  ) %>%
-  gather(Category, count, -c(county)) %>%
-  ## na.rm = TRUE ensures all values are NA are taken as 0
-  ggplot(aes(x=county,y=count))+
-  geom_bar(aes(fill=Category),   # fill depends on cond2
-           stat="identity",
-           colour="black",    # Black outline for all
-           position=position_dodge())+
-  ylab("Proportion of households NOT receiving assistance")+
-  xlab("County")+
-  labs(color = "Percentage of hh_income spent on rent")+
-  theme(legend.position="top") +
-  ggtitle("")
+prop_county_50 <- data_county %>%
+    mutate(rent_above50=(rent_above50-reported_HUD)/rent_above50) %>%
+    select(county,rent_above50) %>%
+    dplyr::rename(
+        'Households spending 50%+ income on rent' = rent_above50
+    ) %>%
+    gather(Category, count, -c(county)) %>%
+    ## na.rm = TRUE ensures all values are NA are taken as 0
+    ggplot(aes(x=county,y=count)) +
+    prop_county_common_elements
+

--- a/app/Scripts/county.R
+++ b/app/Scripts/county.R
@@ -32,7 +32,9 @@ number_county_common_layers <- list(
     ylab("Number of households"),
     xlab("County"),
     theme_minimal(),
-    scale_fill_brewer(palette = "Set2", direction = -1)
+    scale_y_continuous(limits = c(0, 30000)),
+    scale_fill_brewer(palette = "Set2", direction = -1),
+    coord_flip()
 )
 
 number_county_30 <- data_county %>%  

--- a/app/Scripts/county.R
+++ b/app/Scripts/county.R
@@ -30,7 +30,6 @@ number_county_common_layers <- list(
              stat = "identity",
              position = position_dodge()),
     ylab("Number of households"),
-    xlab("County"),
     theme_minimal(),
     scale_y_continuous(limits = c(0, 30000)),
     scale_fill_brewer(palette = "Set2", direction = -1),

--- a/app/Scripts/county.R
+++ b/app/Scripts/county.R
@@ -2,6 +2,7 @@ library(shiny)
 library(tidyverse)
 library(plotly)
 library(sf)
+library(RColorBrewer)
 
 # Load Data
 acs_hud_de_geojoined <- read_rds("acs_hud_de_geojoined.rds")
@@ -24,7 +25,7 @@ data_county <- geo_data_nogeometry %>%
               rent_above50 = sum(above50)) 
 
 # Number of households spending above 30% and 50% of hh_income on rent.
-number_county_common_elements <- list(
+number_county_common_layers <- list(
     geom_bar(aes(fill = Category),
              stat = "identity",
              colour = "black",
@@ -40,7 +41,7 @@ number_county_30 <- data_county %>%
         'Spending 30%+ income on rent' = rent_above30) %>%
     gather(Category, count, -c(county)) %>%
     ggplot(aes(x = county, y = count)) + 
-    number_county_common_elements +
+    number_county_common_layers +
     ggtitle("Households Spending 30%+ Income on Rent")
 
 number_county_50 <- data_county %>% 
@@ -50,15 +51,14 @@ number_county_50 <- data_county %>%
         'Spending 50%+ income on rent' = rent_above50) %>%
     gather(Category, count, -c(county)) %>%
     ggplot(aes(x = county, y = count))+
-    number_county_common_elements +
+    number_county_common_layers +
     ggtitle("Households Spending 50%+ Income on Rent")
 
 # Proportion of households spending above 30% and 50% of hh_income on rent and not receiving assitance.
-prop_county_common_elements <- list(
-    geom_bar(aes(fill = Category),
+prop_county_common_layers <- list(
+    geom_bar(fill = "gray",
              stat = "identity",
-             position = position_dodge(),
-             width = 0.6),
+             width = 0.3),
     scale_y_continuous(labels = scales::percent,
                        limits = c(0, 1)),
     ylab(""),
@@ -76,7 +76,7 @@ prop_county_30 <- data_county %>%
         'Households spending 30%+ income on rent' = rent_above30) %>%
     gather(Category, count, -c(county)) %>%
     ggplot(aes(x = county, y = count)) + 
-    prop_county_common_elements
+    prop_county_common_layers
 
 prop_county_50 <- data_county %>%
     mutate(rent_above50 = (rent_above50 - reported_HUD) / rent_above50) %>%
@@ -87,5 +87,5 @@ prop_county_50 <- data_county %>%
     gather(Category, count, -c(county)) %>%
     ## na.rm = TRUE ensures all values are NA are taken as 0
     ggplot(aes(x = county,y = count)) +
-    prop_county_common_elements
+    prop_county_common_layers
 

--- a/app/Scripts/county.R
+++ b/app/Scripts/county.R
@@ -30,7 +30,7 @@ number_county_common_layers <- list(
              stat = "identity",
              position = position_dodge()),
     ylab("Number of households"),
-    xlab("County"),
+    xlab(""),
     theme_minimal(),
     scale_y_continuous(limits = c(0, 30000)),
     scale_fill_brewer(palette = "Set2", direction = -1),

--- a/app/Scripts/county.R
+++ b/app/Scripts/county.R
@@ -28,10 +28,11 @@ data_county <- geo_data_nogeometry %>%
 number_county_common_layers <- list(
     geom_bar(aes(fill = Category),
              stat = "identity",
-             colour = "black",
              position = position_dodge()),
     ylab("Number of households"),
-    xlab("County")
+    xlab("County"),
+    theme_minimal(),
+    scale_fill_brewer(palette = "Set2", direction = -1)
 )
 
 number_county_30 <- data_county %>%  
@@ -56,7 +57,7 @@ number_county_50 <- data_county %>%
 
 # Proportion of households spending above 30% and 50% of hh_income on rent and not receiving assitance.
 prop_county_common_layers <- list(
-    geom_bar(fill = "gray",
+    geom_bar(fill = "#fa9fb5",
              stat = "identity",
              width = 0.3),
     scale_y_continuous(labels = scales::percent,

--- a/app/Scripts/county.R
+++ b/app/Scripts/county.R
@@ -30,6 +30,7 @@ number_county_common_layers <- list(
              stat = "identity",
              position = position_dodge()),
     ylab("Number of households"),
+    xlab("County"),
     theme_minimal(),
     scale_y_continuous(limits = c(0, 30000)),
     scale_fill_brewer(palette = "Set2", direction = -1),

--- a/app/Scripts/county.R
+++ b/app/Scripts/county.R
@@ -80,12 +80,12 @@ prop_county_30 <- data_county %>%
 
 prop_county_50 <- data_county %>%
     mutate(rent_above50 = (rent_above50 - reported_HUD) / rent_above50) %>%
-    select(county,rent_above50) %>%
+    select(county, rent_above50) %>%
     dplyr::rename(
         'Households spending 50%+ income on rent' = rent_above50
     ) %>%
     gather(Category, count, -c(county)) %>%
     ## na.rm = TRUE ensures all values are NA are taken as 0
-    ggplot(aes(x=county,y=count)) +
+    ggplot(aes(x = county,y = count)) +
     prop_county_common_elements
 

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -117,3 +117,8 @@
     display: flex;
     justify-content: center;
 }
+
+#prop_county {
+    margin: auto;
+    max-width: 800px;
+}


### PR DESCRIPTION
This PR fixes small typos (fix #50) and makes the bar plots horizontal. 

I also modified the `county.R` file to reduce the code re-use--I bundled common ggplot layers into a list and reuse them throughout.