### PR TITLE
Order counties in a consistent manner & color changes

### DIFF
--- a/app/Scripts/county.R
+++ b/app/Scripts/county.R
@@ -4,12 +4,7 @@ library(plotly)
 library(sf)
 library(RColorBrewer)
 
-# Load Data
-acs_hud_de_geojoined <- read_rds("acs_hud_de_geojoined.rds")
-geo_data <- acs_hud_de_geojoined
-geo_data_nogeometry <- geo_data %>% 
-    st_drop_geometry()
-
+# Create by-county table (data object inherited from server.R)
 data_county <- geo_data_nogeometry %>%
     filter(number_reported > 0) %>%
     mutate(county = substr(GEOID, 3, 5)) %>%
@@ -37,22 +32,26 @@ number_county_common_layers <- list(
     coord_flip()
 )
 
-number_county_30 <- data_county %>%  
+number_county_30_data <- data_county %>%  
     select(reported_HUD, rent_above30, county) %>%
     dplyr::rename(
         'Receiving Voucher' = reported_HUD,
         'Spending 30%+ income on rent' = rent_above30) %>%
-    gather(Category, count, -c(county)) %>%
+    gather(Category, count, -c(county))
+    
+number_county_30 <-  number_county_30_data %>%
     ggplot(aes(x = county, y = count)) + 
     number_county_common_layers +
     ggtitle("Households Spending 30%+ Income on Rent")
 
-number_county_50 <- data_county %>% 
+number_county_50_data <- data_county %>% 
     select(reported_HUD, rent_above50, county) %>%
     dplyr::rename(
         'Receiving Voucher' = reported_HUD,
         'Spending 50%+ income on rent' = rent_above50) %>%
-    gather(Category, count, -c(county)) %>%
+    gather(Category, count, -c(county))
+
+number_county_50 <- number_county_50_data %>%
     ggplot(aes(x = county, y = count))+
     number_county_common_layers +
     ggtitle("Households Spending 50%+ Income on Rent")
@@ -72,18 +71,22 @@ prop_county_common_layers <- list(
     ggtitle("Potentialy-Eligible Households Not Receiving Voucher")
 )
 
-prop_county_30 <- data_county %>% 
+prop_county_30_data <- data_county %>% 
     mutate(rent_above30 = (rent_above30 - reported_HUD) / rent_above30) %>%
-    select(county, rent_above30) %>%
+    select(county, rent_above30)
+
+prop_county_30 <- prop_county_30_data %>%
     dplyr::rename(
         'Households spending 30%+ income on rent' = rent_above30) %>%
     gather(Category, count, -c(county)) %>%
     ggplot(aes(x = county, y = count)) + 
     prop_county_common_layers
 
-prop_county_50 <- data_county %>%
+prop_county_50_data <- data_county %>%
     mutate(rent_above50 = (rent_above50 - reported_HUD) / rent_above50) %>%
-    select(county, rent_above50) %>%
+    select(county, rent_above50)
+
+prop_county_50 <- prop_county_50_data %>%
     dplyr::rename(
         'Households spending 50%+ income on rent' = rent_above50
     ) %>%

--- a/app/Scripts/county.R
+++ b/app/Scripts/county.R
@@ -28,9 +28,17 @@ number_county_common_layers <- list(
     xlab(""),
     theme_minimal(),
     scale_y_continuous(limits = c(0, 30000)),
-    scale_fill_brewer(palette = "Set2", direction = -1),
+    scale_fill_brewer(palette = "Set2", direction = 1, name = ""),
     coord_flip()
 )
+
+plotly_legend_top_right <- function(p) {
+    layout(p, legend = list(orientation = 'h',
+                         yanchor = "top",
+                         y = 1.03,
+                         xanchor = "right",
+                         x = 1))
+}
 
 number_county_30_data <- data_county %>%  
     select(reported_HUD, rent_above30, county) %>%
@@ -39,10 +47,14 @@ number_county_30_data <- data_county %>%
         'Spending 30%+ income on rent' = rent_above30) %>%
     gather(Category, count, -c(county))
     
-number_county_30 <-  number_county_30_data %>%
+number_county_30 <- number_county_30_data %>%
     ggplot(aes(x = county, y = count)) + 
     number_county_common_layers +
     ggtitle("Households Spending 30%+ Income on Rent")
+
+number_county_30 <- number_county_30 %>%
+    ggplotly() %>%
+    plotly_legend_top_right()
 
 number_county_50_data <- data_county %>% 
     select(reported_HUD, rent_above50, county) %>%
@@ -55,6 +67,14 @@ number_county_50 <- number_county_50_data %>%
     ggplot(aes(x = county, y = count))+
     number_county_common_layers +
     ggtitle("Households Spending 50%+ Income on Rent")
+
+number_county_50 <- number_county_50 %>%
+    ggplotly() %>%
+    plotly_legend_top_right()
+
+# Proportion of households eligible vs participating in the voucher program
+# (currently in the main server file)
+
 
 # Proportion of households spending above 30% and 50% of hh_income on rent and not receiving assitance.
 prop_county_common_layers <- list(

--- a/app/Scripts/county.R
+++ b/app/Scripts/county.R
@@ -27,6 +27,7 @@ number_county_common_layers <- list(
     ylab("Number of households"),
     xlab(""),
     theme_minimal(),
+    scale_x_discrete(limits = rev(c("New Castle", "Kent", "Sussex"))),
     scale_y_continuous(limits = c(0, 30000)),
     scale_fill_brewer(palette = "Set2", direction = 1, name = ""),
     coord_flip()
@@ -35,7 +36,7 @@ number_county_common_layers <- list(
 plotly_legend_top_right <- function(p) {
     layout(p, legend = list(orientation = 'h',
                          yanchor = "top",
-                         y = 1.03,
+                         y = 1.05,
                          xanchor = "right",
                          x = 1))
 }

--- a/app/Scripts/county.R
+++ b/app/Scripts/county.R
@@ -84,7 +84,7 @@ prop_county_common_layers <- list(
     scale_y_continuous(labels = scales::percent,
                        limits = c(0, 1)),
     scale_x_discrete(limits = rev(c("New Castle", "Kent", "Sussex"))),
-    scale_fill_manual(values = c("#F27405", "gray")),
+    scale_fill_manual(values = c("#FC8D62", "gray")),
     ylab(""),
     xlab(""),
     theme_minimal(),

--- a/app/Scripts/county.R
+++ b/app/Scripts/county.R
@@ -58,12 +58,12 @@ number_county_50 <- number_county_50_data %>%
 
 # Proportion of households spending above 30% and 50% of hh_income on rent and not receiving assitance.
 prop_county_common_layers <- list(
-    geom_bar(fill = "#F27405",
-             stat = "identity",
+    geom_bar(stat = "identity",
              width = 0.3),
     scale_y_continuous(labels = scales::percent,
                        limits = c(0, 1)),
     scale_x_discrete(limits = rev(c("New Castle", "Kent", "Sussex"))),
+    scale_fill_manual(values = c("#F27405", "gray")),
     ylab(""),
     xlab(""),
     theme_minimal(),
@@ -76,11 +76,16 @@ prop_county_data <- data_county %>%
     mutate(rent_above30_prop = (rent_above30 - reported_HUD) / rent_above30,
            rent_above50_prop = (rent_above50 - reported_HUD) / rent_above50)
 
+# Add fill color 
+prop_county_data <- prop_county_data %>%
+    mutate(highlighted = case_when(max(rent_above30_prop) == rent_above30_prop ~ "highlighted",
+                                  TRUE ~ "none"))
+
 prop_county_30 <- prop_county_data %>%
-    ggplot(aes(x = county, y = rent_above30_prop)) +
+    ggplot(aes(x = county, y = rent_above30_prop, fill = highlighted)) +
     prop_county_common_layers
 
 prop_county_50 <- prop_county_data %>%
-    ggplot(aes(x = county,y = rent_above50_prop)) +
+    ggplot(aes(x = county,y = rent_above50_prop, fill = highlighted)) +
     prop_county_common_layers
 

--- a/app/Scripts/county.R
+++ b/app/Scripts/county.R
@@ -71,27 +71,15 @@ prop_county_common_layers <- list(
     ggtitle("Potentialy-Eligible Households Not Receiving Voucher")
 )
 
-prop_county_30_data <- data_county %>% 
-    mutate(rent_above30 = (rent_above30 - reported_HUD) / rent_above30) %>%
-    select(county, rent_above30)
+prop_county_data <- data_county %>% 
+    mutate(rent_above30_prop = (rent_above30 - reported_HUD) / rent_above30,
+           rent_above50_prop = (rent_above50 - reported_HUD) / rent_above50)
 
-prop_county_30 <- prop_county_30_data %>%
-    dplyr::rename(
-        'Households spending 30%+ income on rent' = rent_above30) %>%
-    gather(Category, count, -c(county)) %>%
-    ggplot(aes(x = county, y = count)) + 
+prop_county_30 <- prop_county_data %>%
+    ggplot(aes(x = county, y = rent_above30_prop)) +
     prop_county_common_layers
 
-prop_county_50_data <- data_county %>%
-    mutate(rent_above50 = (rent_above50 - reported_HUD) / rent_above50) %>%
-    select(county, rent_above50)
-
-prop_county_50 <- prop_county_50_data %>%
-    dplyr::rename(
-        'Households spending 50%+ income on rent' = rent_above50
-    ) %>%
-    gather(Category, count, -c(county)) %>%
-    ## na.rm = TRUE ensures all values are NA are taken as 0
-    ggplot(aes(x = county,y = count)) +
+prop_county_50 <- prop_county_data %>%
+    ggplot(aes(x = county,y = rent_above50_prop)) +
     prop_county_common_layers
 

--- a/app/Scripts/county.R
+++ b/app/Scripts/county.R
@@ -58,11 +58,12 @@ number_county_50 <- number_county_50_data %>%
 
 # Proportion of households spending above 30% and 50% of hh_income on rent and not receiving assitance.
 prop_county_common_layers <- list(
-    geom_bar(fill = "#fa9fb5",
+    geom_bar(fill = "#F27405",
              stat = "identity",
              width = 0.3),
     scale_y_continuous(labels = scales::percent,
                        limits = c(0, 1)),
+    scale_x_discrete(limits = rev(c("New Castle", "Kent", "Sussex"))),
     ylab(""),
     xlab(""),
     theme_minimal(),

--- a/app/server.R
+++ b/app/server.R
@@ -101,12 +101,12 @@ shinyServer(function(input, output, session) {
         })
     
     output$prop_counties <- renderPlotly({
-        cur_data <- geo_long %>%
+        prop_counties_data <- geo_long %>%
             group_by(county_name, labels) %>%
             summarise(count = sum(value, na.rm = TRUE)) %>%
             mutate(prop = count / sum(count))
         
-        out_plot <- cur_data %>%
+        prop_counties_plot <- prop_counties_data %>%
             ggplot(aes(x = county_name, y = prop, fill = labels,
                        label = paste(scales::percent(prop)))) +
             geom_bar(position = "fill", 
@@ -123,7 +123,7 @@ shinyServer(function(input, output, session) {
             xlab("") +
             ggtitle("Renters Potentially Eligible for Voucher") +
             coord_flip()
-        out_plot %>%
+        prop_counties_plot %>%
             ggplotly() %>%
             plotly_legend_top_right
     })

--- a/app/server.R
+++ b/app/server.R
@@ -116,6 +116,7 @@ shinyServer(function(input, output, session) {
             geom_text(color = "white") + 
             scale_y_continuous(labels = scales::percent) +
             scale_fill_brewer(palette = "Set2", name = "") + 
+            scale_fill_brewer(palette = "Set2", name = "", direction = -1) + 
             scale_x_discrete(limits = rev(c("New Castle",
                                             "Kent",
                                             "Sussex"))) + 

--- a/app/server.R
+++ b/app/server.R
@@ -77,8 +77,8 @@ shinyServer(function(input, output, session) {
                     insidetextorientation = 'horizontal',
                     showlegend = FALSE,
                     marker = list(
-                        colors = c("#ED8B00", # Tech Impact orange
-                                   "#78BE20") # Tech Impact green
+                        colors = c("#FC8D62", # Brewer Set 2 orange
+                                   "#66C2A5") # Brewer Set 2 green
                     )) %>%
             layout(title = list(text = mainplot_title),
                    margin = list(t = 100))

--- a/app/server.R
+++ b/app/server.R
@@ -75,7 +75,11 @@ shinyServer(function(input, output, session) {
                     type = 'pie',
                     textinfo = 'label+percent',
                     insidetextorientation = 'horizontal',
-                    showlegend = FALSE) %>%
+                    showlegend = FALSE,
+                    marker = list(
+                        colors = c("#ED8B00", # Tech Impact orange
+                                   "#78BE20") # Tech Impact green
+                    )) %>%
             layout(title = list(text = mainplot_title),
                    margin = list(t = 100))
         
@@ -123,9 +127,11 @@ shinyServer(function(input, output, session) {
             xlab("") +
             ggtitle("Renters Potentially Eligible for Voucher") +
             coord_flip()
+        
         prop_counties_plot %>%
             ggplotly() %>%
-            plotly_legend_top_right
+            plotly_legend_top_right %>%
+            layout(legend = list(traceorder = "reversed"))
     })
     
     output$prop_county <- renderPlotly({

--- a/app/server.R
+++ b/app/server.R
@@ -115,7 +115,6 @@ shinyServer(function(input, output, session) {
             theme_minimal() +
             geom_text(color = "white") + 
             scale_y_continuous(labels = scales::percent) +
-            scale_fill_brewer(palette = "Set2", name = "") + 
             scale_fill_brewer(palette = "Set2", name = "", direction = -1) + 
             scale_x_discrete(limits = rev(c("New Castle",
                                             "Kent",
@@ -126,7 +125,7 @@ shinyServer(function(input, output, session) {
             coord_flip()
         out_plot %>%
             ggplotly() %>%
-            layout(legend = list(orientation = 'h'))
+            plotly_legend_top_right
     })
     
     output$prop_county <- renderPlotly({


### PR DESCRIPTION
This PR orders counties in a consistent manner, fixing #56.

I also made the use of color consistent so that we are depicting voucher participants as green and those who are not served as orange. 

The PR also includes various tweaks including repositioning legends and optimizing the plotting routine.