### PR TITLE
Disable zoom in plotly visualizations 

### DIFF
--- a/app/Scripts/county.R
+++ b/app/Scripts/county.R
@@ -33,13 +33,6 @@ number_county_common_layers <- list(
     coord_flip()
 )
 
-plotly_legend_top_right <- function(p) {
-    layout(p, legend = list(orientation = 'h',
-                         yanchor = "top",
-                         y = 1.05,
-                         xanchor = "right",
-                         x = 1))
-}
 
 number_county_30_data <- data_county %>%  
     select(reported_HUD, rent_above30, county) %>%

--- a/app/home_panel.r
+++ b/app/home_panel.r
@@ -41,7 +41,7 @@ home_panel <- tabPanel(
     tags$div(
         class = "main-point--container",
         tags$div(class = "main-point",
-                 "Want to learn more about how your neighboorhod is doing?"
+                 "Want to learn more about how your neighborhood is doing?"
         ),
         actionLink(inputId = "to_advocates_page", 
                    label = "Check out our Housing Voucher Lookup Tool",

--- a/app/scripts/advocates.R
+++ b/app/scripts/advocates.R
@@ -1,0 +1,48 @@
+library(shiny)
+library(tidyverse)
+library(plotly)
+library(sf)
+library(leaflet)
+library(tigris)
+
+
+shape <- tracts(state='10') %>% select(GEOID, NAMELSAD, NAME)
+# lat <- 39.1824#39.5393
+# lng <- -75.2
+# advoc_map <- shape %>%
+#   leaflet() %>%
+#   addTiles(providers$CartoDB.Positron) %>%   #not including one, sets the general maps version
+#   setView(lng, lat, zoom = 8.0) %>%
+#   addPolygons(fillColor = "blue",
+#               highlight=highlightOptions(weight=5,
+#                                          color='red',
+#                                          fillOpacity = 0.7,
+#                                          bringToFront=TRUE),
+#               label= ~NAMELSAD, layerId = ~GEOID)
+
+
+
+# Load Data
+acs_hud_de_geojoined <- read_rds("acs_hud_de_geojoined.rds")
+geo_data <- acs_hud_de_geojoined
+geo_data_nogeometry <- geo_data %>% 
+  st_drop_geometry()
+
+advoc_table <- geo_data_nogeometry %>% 
+  #mutate(reported_labels=ifelse(number_reported==-4,"Less than 10 Households","NA")) %>%
+  #mutate(number_reported =replace(number_reported, number_reported<0, 0) ) %>%
+  rowwise() %>%
+  mutate(above30 = sum(rent_30E, rent_35E, rent_40E,rent_50E),
+         above50=rent_50E) %>%
+  group_by(GEOID) %>%
+  summarize(reported_HUD=sum(number_reported),rent_above30=sum(above30),rent_above50=sum(above50)) %>%
+  mutate_at(vars(reported_HUD),as.integer) %>%
+  mutate_at(vars(rent_above30),as.integer) %>%
+  mutate_at(vars(rent_above50),as.integer) %>%
+  dplyr::rename(
+    '# Receiving assisstance'=reported_HUD,
+    '# Spending 30%+ of income on rent'=rent_above30,
+    '# Spending 50%+ of income on rent'=rent_above50,
+  ) 
+  
+advoc_table <- inner_join(advoc_table,shape,by='GEOID') 

--- a/app/scripts/county.R
+++ b/app/scripts/county.R
@@ -1,0 +1,105 @@
+library(shiny)
+library(tidyverse)
+library(plotly)
+library(sf)
+library(RColorBrewer)
+
+# Create by-county table (data object inherited from server.R)
+data_county <- geo_data_nogeometry %>%
+    filter(number_reported > 0) %>%
+    mutate(county = substr(GEOID, 3, 5)) %>%
+    mutate(county=replace(county, county=='001', 'Kent')) %>%
+    mutate(county=replace(county, county=='003', 'New Castle')) %>%
+    mutate(county=replace(county, county=='005', 'Sussex'))  %>%
+    rowwise() %>% 
+    mutate(above30 = sum(rent_30E, rent_35E, rent_40E,rent_50E),
+           above50 = rent_50E) %>%
+    group_by(county) %>%
+    summarize(reported_HUD = sum(number_reported),
+              rent_above30 = sum(above30),
+              rent_above50 = sum(above50)) 
+
+# Number of households spending above 30% and 50% of hh_income on rent.
+number_county_common_layers <- list(
+    geom_bar(aes(fill = Category),
+             stat = "identity",
+             position = position_dodge()),
+    ylab("Number of households"),
+    xlab(""),
+    theme_minimal(),
+    scale_x_discrete(limits = rev(c("New Castle", "Kent", "Sussex"))),
+    scale_y_continuous(limits = c(0, 30000)),
+    scale_fill_brewer(palette = "Set2", direction = 1, name = ""),
+    coord_flip()
+)
+
+
+number_county_30_data <- data_county %>%  
+    select(reported_HUD, rent_above30, county) %>%
+    dplyr::rename(
+        'Receiving Voucher' = reported_HUD,
+        'Spending 30%+ income on rent' = rent_above30) %>%
+    gather(Category, count, -c(county))
+    
+number_county_30 <- number_county_30_data %>%
+    ggplot(aes(x = county, y = count)) + 
+    number_county_common_layers +
+    ggtitle("Households Spending 30%+ Income on Rent")
+
+number_county_30 <- number_county_30 %>%
+    ggplotly() %>%
+    plotly_legend_top_right()
+
+number_county_50_data <- data_county %>% 
+    select(reported_HUD, rent_above50, county) %>%
+    dplyr::rename(
+        'Receiving Voucher' = reported_HUD,
+        'Spending 50%+ income on rent' = rent_above50) %>%
+    gather(Category, count, -c(county))
+
+number_county_50 <- number_county_50_data %>%
+    ggplot(aes(x = county, y = count))+
+    number_county_common_layers +
+    ggtitle("Households Spending 50%+ Income on Rent")
+
+number_county_50 <- number_county_50 %>%
+    ggplotly() %>%
+    plotly_legend_top_right()
+
+# Proportion of households eligible vs participating in the voucher program
+# (currently in the main server file)
+
+
+# Proportion of households spending above 30% and 50% of hh_income on rent and not receiving assitance.
+prop_county_common_layers <- list(
+    geom_bar(stat = "identity",
+             width = 0.3),
+    scale_y_continuous(labels = scales::percent,
+                       limits = c(0, 1)),
+    scale_x_discrete(limits = rev(c("New Castle", "Kent", "Sussex"))),
+    scale_fill_manual(values = c("#FC8D62", "gray")),
+    ylab(""),
+    xlab(""),
+    theme_minimal(),
+    theme(legend.position = "none"),
+    coord_flip(),
+    ggtitle("Potentialy-Eligible Households Not Receiving Voucher")
+)
+
+prop_county_data <- data_county %>% 
+    mutate(rent_above30_prop = (rent_above30 - reported_HUD) / rent_above30,
+           rent_above50_prop = (rent_above50 - reported_HUD) / rent_above50)
+
+# Add fill color 
+prop_county_data <- prop_county_data %>%
+    mutate(highlighted = case_when(max(rent_above30_prop) == rent_above30_prop ~ "highlighted",
+                                  TRUE ~ "none"))
+
+prop_county_30 <- prop_county_data %>%
+    ggplot(aes(x = county, y = rent_above30_prop, fill = highlighted)) +
+    prop_county_common_layers
+
+prop_county_50 <- prop_county_data %>%
+    ggplot(aes(x = county,y = rent_above50_prop, fill = highlighted)) +
+    prop_county_common_layers
+

--- a/app/scripts/plotly_settings.R
+++ b/app/scripts/plotly_settings.R
@@ -1,0 +1,17 @@
+# Plotly Settings
+
+# Place the lenged on top right
+plotly_legend_top_right <- function(p) {
+    layout(p, legend = list(orientation = 'h',
+                            yanchor = "top",
+                            y = 1.05,
+                            xanchor = "right",
+                            x = 1))
+}
+
+
+plotly_disable_zoom <- function(p) {
+    p %>%
+        layout(xaxis = list(fixedrange = TRUE),
+               yaxis = list(fixedrange = TRUE))
+}

--- a/app/scripts/plotly_settings.R
+++ b/app/scripts/plotly_settings.R
@@ -15,3 +15,8 @@ plotly_disable_zoom <- function(p) {
         layout(xaxis = list(fixedrange = TRUE),
                yaxis = list(fixedrange = TRUE))
 }
+
+plotly_hide_modebar <- function(p) {
+    p %>%
+        config(displayModeBar = FALSE)
+}

--- a/app/server.R
+++ b/app/server.R
@@ -98,11 +98,14 @@ shinyServer(function(input, output, session) {
     
     output$number_county <- renderPlotly({
         if(input$selectedNumber == "30"){
-            mainplot_data <- number_county_30 
+            current_plot <- number_county_30 
         } 
         else {
-            mainplot_data <- number_county_50
+            current_plot <- number_county_50
         }
+        current_plot %>% 
+            ggplotly() %>%
+            plotly_disable_zoom()
         })
     
     output$prop_counties <- renderPlotly({
@@ -137,13 +140,16 @@ shinyServer(function(input, output, session) {
     
     output$prop_county <- renderPlotly({
         if(input$selectedProp == "30"){
-            mainplot_data <- prop_county_30 
+            current_plot <- prop_county_30
         } 
         else {
-            mainplot_data <- prop_county_50
+            current_plot <- prop_county_50
         }
+        current_plot %>%
+            ggplotly() %>%
+            plotly_disable_zoom()
         })
-    output$prop_county_50 <- renderPlotly({prop_county_50})
+    
     output$advoc_table <- renderTable({advoc_table %>% filter(NAMELSAD %in% input$GEOID_selector) %>%  
             dplyr::rename('Census Tract'=NAME) %>% 
             select('Census Tract',GEOID,'# Receiving assisstance',

--- a/app/server.R
+++ b/app/server.R
@@ -63,7 +63,7 @@ shinyServer(function(input, output, session) {
         }
         
         # Determine the title of the plot
-        mainplot_title <- paste("Renters Potentially Eligible for Housing Choice Voucher",
+        mainplot_title <- paste("Renters Potentially Eligible for <br> Housing Choice Voucher",
                                 county_list[[input$selectedCounty]],
                                 sep = "<br>")
         
@@ -81,8 +81,12 @@ shinyServer(function(input, output, session) {
                         colors = c("#FC8D62", # Brewer Set 2 orange
                                    "#66C2A5") # Brewer Set 2 green
                     )) %>%
-            layout(title = list(text = mainplot_title),
-                   margin = list(t = 100))
+            layout(title = list(text = mainplot_title,
+                                pad = list(b = 20),
+                                y = 0.95,
+                                yanchor = "top"),
+                   margin = list(t = 100)) %>%
+            plotly_hide_modebar()
         
     })
     
@@ -105,7 +109,8 @@ shinyServer(function(input, output, session) {
         }
         current_plot %>% 
             ggplotly() %>%
-            plotly_disable_zoom()
+            plotly_disable_zoom() %>%
+            plotly_hide_modebar
         })
     
     output$prop_counties <- renderPlotly({
@@ -134,8 +139,10 @@ shinyServer(function(input, output, session) {
         
         prop_counties_plot %>%
             ggplotly() %>%
+            layout(legend = list(traceorder = "reversed")) %>%
             plotly_legend_top_right %>%
-            layout(legend = list(traceorder = "reversed"))
+            plotly_disable_zoom() %>%
+            plotly_hide_modebar()
     })
     
     output$prop_county <- renderPlotly({
@@ -147,7 +154,8 @@ shinyServer(function(input, output, session) {
         }
         current_plot %>%
             ggplotly() %>%
-            plotly_disable_zoom()
+            plotly_disable_zoom() %>%
+            plotly_hide_modebar
         })
     
     output$advoc_table <- renderTable({advoc_table %>% filter(NAMELSAD %in% input$GEOID_selector) %>%  

--- a/app/server.R
+++ b/app/server.R
@@ -3,8 +3,9 @@ library(tidyverse)
 library(plotly)
 library(sf)
 
-source("Scripts/advocates.R")
-source("Scripts/county.R")
+source("scripts/advocates.R")
+source("scripts/county.R")
+source("scripts/plotly_settings.R")
 
 # Load Data
 acs_hud_de_geojoined <- read_rds("acs_hud_de_geojoined.rds")

--- a/app/server.R
+++ b/app/server.R
@@ -3,9 +3,9 @@ library(tidyverse)
 library(plotly)
 library(sf)
 
+source("scripts/plotly_settings.R")
 source("scripts/advocates.R")
 source("scripts/county.R")
-source("scripts/plotly_settings.R")
 
 # Load Data
 acs_hud_de_geojoined <- read_rds("acs_hud_de_geojoined.rds")
@@ -140,7 +140,7 @@ shinyServer(function(input, output, session) {
         prop_counties_plot %>%
             ggplotly() %>%
             layout(legend = list(traceorder = "reversed")) %>%
-            plotly_legend_top_right %>%
+            plotly_legend_top_right() %>%
             plotly_disable_zoom() %>%
             plotly_hide_modebar()
     })


### PR DESCRIPTION
This PR disables zoom and other tools (`modebar`) in the plotly visualizations (fixes #66).

I created a separate R file to document the plotly settings. (`plotly_settings.R`)

Also, I renamed the `Script` folder to `script`, so that the folder naming is consistent with other folders in this repo.