### PR TITLE
Add a footnote for the table describing `10` and `NA`

### DIFF
--- a/app/advocates_panel.r
+++ b/app/advocates_panel.r
@@ -11,5 +11,10 @@ advocates_panel <- tabPanel(
     tags$div(class = "advoc-table",
              tableOutput("advoc_table")),
     tags$div(class = "advoc-table",
-             downloadButton("downloadData", "Download"))
+             downloadButton("downloadData", "Download")),
+    tags$div(class = "table-footnote",
+             "The number of households appears as 10 when there are 10 or less 
+             households in a given cell. 
+             NA indicates that there are no households participating in
+             Section 8 for the given census tract, according to HUD.")
 )

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -76,6 +76,14 @@
     justify-content: center;
 }
 
+.table-footnote {
+    text-align: center;
+    color: gray;
+    margin: auto;
+    margin-top: 2.5rem;
+    max-width: 70rem;
+}
+
 .comment {
     text-align: center;
     color: gray;


### PR DESCRIPTION
This PR adds a footnote to the advocate's table, describing the following:
- "10" = there are 10 or fewer counts for the households receiving a voucher 
- "NA" = HUD does not report data for the given census tract

Fixes #67 