### PR TITLE
Update the labels in the pie chat tooltips to "Eligible Families"

### DIFF
--- a/app/scripts/county.R
+++ b/app/scripts/county.R
@@ -48,10 +48,6 @@ number_county_30 <- number_county_30_data %>%
     number_county_common_layers +
     ggtitle("Families Spending 30%+ Income on Rent")
 
-number_county_30 <- number_county_30 %>%
-    ggplotly() %>%
-    plotly_legend_top_right()
-
 number_county_50_data <- data_county %>% 
     select(reported_HUD, rent_above50, county) %>%
     dplyr::rename(
@@ -63,8 +59,4 @@ number_county_50 <- number_county_50_data %>%
     ggplot(aes(x = county, y = count))+
     number_county_common_layers +
     ggtitle("Families Spending 50%+ Income on Rent")
-
-number_county_50 <- number_county_50 %>%
-    ggplotly() %>%
-    plotly_legend_top_right()
 

--- a/app/scripts/county.R
+++ b/app/scripts/county.R
@@ -26,7 +26,7 @@ number_county_common_layers <- list(
     geom_bar(aes(fill = Category),
              stat = "identity",
              position = position_dodge()),
-    ylab("Number of households"),
+    ylab("Number of families"),
     xlab(""),
     theme_minimal(),
     scale_x_discrete(limits = rev(c("New Castle", "Kent", "Sussex"))),
@@ -46,7 +46,7 @@ number_county_30_data <- data_county %>%
 number_county_30 <- number_county_30_data %>%
     ggplot(aes(x = county, y = count)) + 
     number_county_common_layers +
-    ggtitle("Households Spending 30%+ Income on Rent")
+    ggtitle("Families Spending 30%+ Income on Rent")
 
 number_county_30 <- number_county_30 %>%
     ggplotly() %>%
@@ -62,7 +62,7 @@ number_county_50_data <- data_county %>%
 number_county_50 <- number_county_50_data %>%
     ggplot(aes(x = county, y = count))+
     number_county_common_layers +
-    ggtitle("Households Spending 50%+ Income on Rent")
+    ggtitle("Families Spending 50%+ Income on Rent")
 
 number_county_50 <- number_county_50 %>%
     ggplotly() %>%

--- a/app/scripts/county.R
+++ b/app/scripts/county.R
@@ -44,7 +44,8 @@ number_county_30_data <- data_county %>%
     gather(Category, count, -c(county))
     
 number_county_30 <- number_county_30_data %>%
-    ggplot(aes(x = county, y = count)) + 
+    mutate("Eligible Families" = count) %>%
+    ggplot(aes(x = county, y = `Eligible Families`)) + 
     number_county_common_layers +
     ggtitle("Families Spending 30%+ Income on Rent")
 
@@ -56,7 +57,8 @@ number_county_50_data <- data_county %>%
     gather(Category, count, -c(county))
 
 number_county_50 <- number_county_50_data %>%
-    ggplot(aes(x = county, y = count))+
+    mutate("Eligible Families" = count) %>%
+    ggplot(aes(x = county, y = `Eligible Families`)) +
     number_county_common_layers +
     ggtitle("Families Spending 50%+ Income on Rent")
 

--- a/app/scripts/plot_prop_counties.R
+++ b/app/scripts/plot_prop_counties.R
@@ -25,7 +25,7 @@ plot_prop_counties <- function(.data){
         coord_flip()
     
     out_plot <- prop_counties_plot %>%
-        ggplotly() %>%
+        ggplotly(tooltip = "") %>%
         layout(legend = list(traceorder = "reversed")) %>%
         plotly_legend_top_right() %>%
         plotly_disable_zoom() %>%

--- a/app/scripts/plot_prop_counties.R
+++ b/app/scripts/plot_prop_counties.R
@@ -33,3 +33,38 @@ plot_prop_counties <- function(.data){
     
     return(out_plot)
 }
+
+
+prop_counties_data <- .data %>%
+    group_by(county_name, labels) %>%
+    summarise(count = sum(value, na.rm = TRUE)) %>%
+    mutate(prop = count / sum(count))
+
+prop_counties_data %>%
+plot_ly(x = ~prop,
+        y = ~county_name,
+        color = ~labels,
+        type = "bar",
+        orientation = "h",
+        hovertemplate = "%{x} Eligible Families") %>%
+    layout(barmode = "stack",
+           xaxis = list(title = "",
+                        tickformat = ".0%"),
+           yaxis = list(title = "")) %>%
+    add_annotations(yref = "y",
+                    y = ~county_name,
+                    xref = "paper",
+                    x = ~prop ,
+                    text = ~rev(
+                        paste0(round(prop * 100, 2),
+                               "%",
+                               "<br>",
+                                  labels)
+                        ),
+                    showarrow = FALSE) %>%
+    plotly_disable_zoom() %>%
+    plotly_hide_modebar() %>%
+    plotly_legend_top_right()
+
+
+

--- a/app/scripts/plot_prop_counties.R
+++ b/app/scripts/plot_prop_counties.R
@@ -34,37 +34,3 @@ plot_prop_counties <- function(.data){
     return(out_plot)
 }
 
-
-prop_counties_data <- .data %>%
-    group_by(county_name, labels) %>%
-    summarise(count = sum(value, na.rm = TRUE)) %>%
-    mutate(prop = count / sum(count))
-
-prop_counties_data %>%
-plot_ly(x = ~prop,
-        y = ~county_name,
-        color = ~labels,
-        type = "bar",
-        orientation = "h",
-        hovertemplate = "%{x} Eligible Families") %>%
-    layout(barmode = "stack",
-           xaxis = list(title = "",
-                        tickformat = ".0%"),
-           yaxis = list(title = "")) %>%
-    add_annotations(yref = "y",
-                    y = ~county_name,
-                    xref = "paper",
-                    x = ~prop ,
-                    text = ~rev(
-                        paste0(round(prop * 100, 2),
-                               "%",
-                               "<br>",
-                                  labels)
-                        ),
-                    showarrow = FALSE) %>%
-    plotly_disable_zoom() %>%
-    plotly_hide_modebar() %>%
-    plotly_legend_top_right()
-
-
-

--- a/app/server.R
+++ b/app/server.R
@@ -102,7 +102,7 @@ shinyServer(function(input, output, session) {
                     type = 'pie',
                     textinfo = 'label+percent',
                     hoverinfo = "text",
-                    hovertemplate = paste("%{value} Families",
+                    hovertemplate = paste("%{value} Eligible Families",
                                           "<extra></extra>",
                                           sep = "<br>"),
                     insidetextorientation = 'horizontal',

--- a/app/server.R
+++ b/app/server.R
@@ -152,19 +152,6 @@ shinyServer(function(input, output, session) {
         }
     })
     
-    output$prop_county <- renderPlotly({
-        if(input$selectedProp == "30"){
-            current_plot <- prop_county_30
-        } 
-        else {
-            current_plot <- prop_county_50
-        }
-        current_plot %>%
-            ggplotly() %>%
-            plotly_disable_zoom() %>%
-            plotly_hide_modebar
-        })
-    
     output$downloadData <- downloadHandler(
         filename = function() {
             paste("voucher_data.csv")

--- a/app/server.R
+++ b/app/server.R
@@ -138,9 +138,10 @@ shinyServer(function(input, output, session) {
             current_plot <- number_county_50
         }
         current_plot %>% 
-            ggplotly() %>%
+            ggplotly(tooltip = "y") %>%
+            plotly_legend_top_right() %>%
             plotly_disable_zoom() %>%
-            plotly_hide_modebar
+            plotly_hide_modebar()
         })
     
     output$prop_counties <- renderPlotly({


### PR DESCRIPTION
This PR updates the tooltip of the pie chart, so that it shows "Eligible Families", instead of "Families":

<img width="561" alt="image" src="https://user-images.githubusercontent.com/17035406/154513181-975631aa-9579-4f68-900c-75cffe1d81a5.png">

Fixes #78 

This PR also includes small changes to tooltips:
1. The tooltips for the number of eligible families will only show counts. I had to rename the variables to achieve this because the ggplotly's tooltip option will show the variable name
2. I removed the tool tip for the horizontal bar chart showing the proportion of renters across counties. I don't think we have pertinent information that we can add to the graph via tooltips (for now) 