### PR TITLE
Adjust the maximum width of the headings to avoid breaking into 3 lines

### DIFF
--- a/app/www/style.css
+++ b/app/www/style.css
@@ -65,6 +65,10 @@
     margin-bottom: 5rem;
     margin-left: auto;
     margin-right: auto;
+    max-width: 24em;
+}
+
+.learn-more--container .main-point {
     max-width: 22em;
 }
 

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -24,7 +24,7 @@
 }
 
 .main-heading-container {
-    background-color: #f7fbff;
+    background-color: #e1e6ed;
     margin-bottom: 2rem;
 }
 


### PR DESCRIPTION
This PR adjusts the maximum widths of the headings so that they will not break into 3 lines on widescreen.

I also adjusted the background color of the headings to a bit darker one (`#e1e6ed`) so that it will show on screens with lesser contrast. (I was looking at the app with my external monitor, and the previous color (`#f7fbff`) was almost indistinguishable from white.

Fix #98 