### PR TITLE
Run the app on Windows

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -26,6 +26,6 @@ if (Sys.info()[['user']] == 'shiny'){
     # Running locally
     options(shiny.port = 7450)
     Sys.setenv(PYTHON_PATH = 'python3')
-    Sys.setenv(VIRTUALENV_NAME = VIRTUALENV_NAME) # exclude '/' => installs into ~/.virtualenvs/
+    Sys.setenv(VIRTUALENV_NAME = paste0("./", VIRTUALENV_NAME)) # exclude '/' => installs into ~/.virtualenvs/
     # RETICULATE_PYTHON is not required locally, RStudio infers it based on the ~/.virtualenvs path
 }

--- a/.Rprofile
+++ b/.Rprofile
@@ -25,7 +25,13 @@ if (Sys.info()[['user']] == 'shiny'){
     
     # Running locally
     options(shiny.port = 7450)
-    Sys.setenv(PYTHON_PATH = 'python3')
-    Sys.setenv(VIRTUALENV_NAME = paste0("./", VIRTUALENV_NAME)) # exclude '/' => installs into ~/.virtualenvs/
+    if(Sys.which("python3") != ""){
+        Sys.setenv(PYTHON_PATH = 'python3')
+    } else if(Sys.which("python") != ""){
+        Sys.setenv(PYTHON_PATH = 'python')
+    } else {
+            print("Neither `python3` or `python` is not in PATH. Make sure that you have Python installed.")
+        } 
+    Sys.setenv(VIRTUALENV_NAME = VIRTUALENV_NAME) # exclude '/' => installs into ~/.virtualenvs/
     # RETICULATE_PYTHON is not required locally, RStudio infers it based on the ~/.virtualenvs path
 }

--- a/.Rprofile
+++ b/.Rprofile
@@ -25,13 +25,15 @@ if (Sys.info()[['user']] == 'shiny'){
     
     # Running locally
     options(shiny.port = 7450)
-    if(Sys.which("python3") != ""){
+    if(Sys.info()[["sysname"]] == "Windows" & Sys.which("python") != "") {
+        Sys.setenv(PYTHON_PATH = 'python')
+    } else if(Sys.which("python3") != ""){
         Sys.setenv(PYTHON_PATH = 'python3')
     } else if(Sys.which("python") != ""){
         Sys.setenv(PYTHON_PATH = 'python')
     } else {
-            print("Neither `python3` or `python` is not in PATH. Make sure that you have Python installed.")
-        } 
+        print("Neither `python3` or `python` is not in PATH. Make sure that you have Python installed.")
+    } 
     Sys.setenv(VIRTUALENV_NAME = VIRTUALENV_NAME) # exclude '/' => installs into ~/.virtualenvs/
     # RETICULATE_PYTHON is not required locally, RStudio infers it based on the ~/.virtualenvs path
 }

--- a/.Rprofile
+++ b/.Rprofile
@@ -2,7 +2,7 @@
 # the environment the app is running in (local vs remote server).
 
 # Edit this name if desired when starting a new app
-VIRTUALENV_NAME = 'my_env'
+VIRTUALENV_NAME = 'voucher-eligibility-env'
 
 
 # ------------------------- Settings (Edit local settings to match your system) -------------------------- #

--- a/app/server.R
+++ b/app/server.R
@@ -2,7 +2,6 @@ library(shiny)
 library(tidyverse)
 library(plotly)
 library(sf)
-library(reticulate)
 
 PYTHON_DEPENDENCIES = c('pip', 'censusgeocode')
 virtualenv_dir = Sys.getenv('VIRTUALENV_NAME')
@@ -11,7 +10,7 @@ python_path = Sys.getenv('PYTHON_PATH')
 reticulate::virtualenv_create(envname = virtualenv_dir, python = python_path)
 reticulate::virtualenv_install(virtualenv_dir, packages = PYTHON_DEPENDENCIES, ignore_installed=TRUE)
 reticulate::use_virtualenv(virtualenv_dir, required = T)
-source_python("scripts/geocode.py")
+reticulate::source_python("scripts/geocode.py")
 
 
 source("scripts/plotly_settings.R")


### PR DESCRIPTION
This PR fixes the bug where we cannot run the app on Windows. (Fixes #93)

Suspected root causes:
1. The original `.Rprofile` file was referring to the command `python3`. On Windows, the command will redirect to a Windows store version of Python. I fixed this by setting the command `python` if the OS is Windows.
2. Corrupt virtual environment. I realized that the virtual environment installed via reticulate was corrupt. I did `reticulate::virtualenv_remove()` to remove the environment. I fixed this issue by creating a unique name for the virtual environment for this repo (to avoid overlaps with other projects).

Next step is to check if @mehak25 can run the app on her machine! 🤞 