### PR TITLE
Layout the table and the graph on the advocates view

### DIFF
--- a/app/advocates_panel.r
+++ b/app/advocates_panel.r
@@ -11,23 +11,24 @@ advocates_panel <- tabPanel(
              textOutput("current_GEOID")),
     leafletOutput("advocmap"),
     tags$div(class = "advoc-container",
-        tags$div(class = "advoc-table",
-            tags$div(class = "div1",
-                     tableOutput("advoc_table"),
-                     downloadButton("downloadData", "Download"),
-                     downloadButton("downloadAll", "Download All"),
-                     tags$div(class = "table-footnote",
-                              "The number of households appears as 10 when there are 10 or less 
-             households in a given cell."))
-            ),
-        tags$div(class = "bar-graph",
-                 tags$div(class = "div1",
-                            plotlyOutput("prop_census"),
-                     radioGroupButtons("selectedCensusProp", 
-                                       label = "Focusing on families with rent spending:",
-                                       choices = c("30%+ of income" = "30",
-                                                   "50%+ of income" = "50"),
-                                       selected='30')))
-        )
+             tags$div(class = "advoc-table-container",
+                      tags$div(class = "advoc-table",
+                               tableOutput("advoc_table")
+                               ),
+                      downloadButton("downloadData", "Download"),
+                      downloadButton("downloadAll", "Download All"),
+                      tags$div(class = "table-footnote",
+                               "The number of households appears as 10 when there are 10 or less 
+             households in a given cell.")
+             ),
+             tags$div(class = "bar-graph",
+                      plotlyOutput("prop_census"),
+                      radioGroupButtons("selectedCensusProp", 
+                                        label = "Focusing on families with rent spending:",
+                                        choices = c("30%+ of income" = "30",
+                                                    "50%+ of income" = "50"),
+                                        selected='30')
+             )
+    )
     
 )

--- a/app/server.R
+++ b/app/server.R
@@ -191,7 +191,7 @@ shinyServer(function(input, output, session) {
     clicked_ids <- reactiveValues(Clicks=vector())
     
     # #if map is clicked, set values
-    observeEvent(input$advocmap_shape_click,{
+    observeEvent(input$advocmap_shape_click, {
         click = input$advocmap_shape_click
         selected_geoid=input$advocmap_shape_click$id
         clicked_ids$Clicks <- c(clicked_ids$Clicks, click$id) # name when clicked, id when unclicked
@@ -235,11 +235,6 @@ shinyServer(function(input, output, session) {
                             label= ~NAMELSAD, layerId = ~NAMELSAD)
         }
         
-        output$advoc_table <- renderTable({advoc_table %>% filter(NAMELSAD %in% clicked_ids$Clicks) %>%  
-                dplyr::rename('Census Tract'=NAME) %>% 
-                select('Census Tract',GEOID,'# Receiving assisstance',
-                       '# Spending 30%+ of income on rent',
-                       '# Spending 50%+ of income on rent') })
         
         output$prop_census <- renderPlotly({
             if(input$selectedCensusProp == "30"){
@@ -259,7 +254,6 @@ shinyServer(function(input, output, session) {
     observeEvent(input$to_advocates_page_bottom, {
         updateNavbarPage(session, inputId =  "main_page", selected = "For Advocates")
     })
-    
     
     # Look for a GEOID for a given address (Python)
     found_GEOID <- reactiveValues(ids=vector())
@@ -303,6 +297,7 @@ shinyServer(function(input, output, session) {
                      }
                  )
                  })
+    
     output$prop_census <- renderPlotly({
         if(input$selectedCensusProp == "30"){
             plot_prop_census(30,clicked_ids$Clicks)
@@ -312,11 +307,13 @@ shinyServer(function(input, output, session) {
         }
     })
     
-    output$advoc_table <- renderTable({advoc_table %>% filter(NAMELSAD %in% clicked_ids$Clicks) %>%  
+    output$advoc_table <- renderTable({
+        output_table <- advoc_table %>% 
+            filter(NAMELSAD %in% clicked_ids$Clicks) %>%  
             dplyr::rename('Census Tract'=NAME) %>% 
             select('Census Tract',GEOID,'# Receiving assisstance',
                    '# Spending 30%+ of income on rent',
-                   '# Spending 50%+ of income on rent') })
-    
-    
+                   '# Spending 50%+ of income on rent') 
+        return(output_table)
+    })
 })

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -84,36 +84,23 @@
     margin-bottom: 6rem;
 }
 
-
-.advoc-table {
-    height:100%;
-    width: 40%; 
-    margin:5px; 
-    float:left;
-}
-.bar-graph {
-    height:100%;
-    width: 40%; 
-    margin:5px; 
-    float:right;
-}
-
-.div1 {
-    top:0;
-    position:absolute;
-}
-.div2 {
-    bottom:0;
-    position:absolute;
-}
-
 .advoc-container {
     display: flex;
+    flex-wrap: wrap;
     text-align: center;
-    font-size: 1rem;
+    font-size: 1.1rem;
     justify-content: center;
-    height:100%;
-    width:100%;
+}
+
+.advoc-table {
+    margin: 5px; 
+    height: 80%;    
+    flex-grow: 3;
+}
+.bar-graph {
+    margin:5px; 
+    flex-grow: 2;
+    max-width: 50rem;
 }
 
 .table-footnote {

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -90,13 +90,20 @@
     text-align: center;
     font-size: 1.1rem;
     justify-content: center;
+    flex-grow: 3;
 }
 
 .advoc-table {
     margin: 5px; 
     height: 80%;    
     flex-grow: 3;
+    min-height: 35rem;
 }
+
+.advoc-table-container {
+    height: 80%;
+}
+
 .bar-graph {
     margin:5px; 
     flex-grow: 2;

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -104,9 +104,8 @@
 }
 
 .bar-graph {
-    margin:5px; 
-    flex-grow: 2;
-    max-width: 50rem;
+    margin-left: 2rem;
+    flex-grow: 1;
 }
 
 .table-footnote {

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -94,9 +94,9 @@
 }
 
 .advoc-table {
-    margin: 5px; 
-    height: 80%;    
-    flex-grow: 3;
+    margin: 1rem;
+    background-color: #f2f2f2;
+    padding: 1rem;
     min-height: 35rem;
 }
 

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -88,7 +88,6 @@
     display: flex;
     flex-wrap: wrap;
     text-align: center;
-    font-size: 1.1rem;
     justify-content: center;
     flex-grow: 3;
 }

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -93,10 +93,10 @@
 }
 
 .advoc-table {
-    margin: 1rem;
     background-color: #f2f2f2;
     padding: 1rem;
     min-height: 35rem;
+    margin-bottom: 1rem;
 }
 
 .advoc-table-container {

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -89,7 +89,7 @@
     flex-wrap: wrap;
     text-align: center;
     justify-content: center;
-    flex-grow: 3;
+    margin-top: 2rem;
 }
 
 .advoc-table {

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -100,7 +100,7 @@
 }
 
 .advoc-table-container {
-    height: 80%;
+    max-width: 70rem;
 }
 
 .bar-graph {


### PR DESCRIPTION
This PR updates the table and the graph on the advocate's view via flexbox. It uses `flex-wrap` to wrap the table and the graph when viewing on a mobile device.