### PR TITLE
Add a line break to the table footnote & update the label of the download button

### DIFF
--- a/app/advocates_panel.r
+++ b/app/advocates_panel.r
@@ -19,12 +19,12 @@ advocates_panel <- tabPanel(
              tags$div(class = "advoc-table-container",
                       tags$div(class = "advoc-table",
                                tableOutput("advoc_table")
-                               ),
+                      ),
                       tableOutput("table_desc"),
                       tags$div(class = "table-footnote",
-                      downloadButton("downloadData", "Download CSV")),
+                               downloadButton("downloadData", "Download")),
                       tags$div(class = "table-footnote","(Dowloads data from above table)"),
-                    tags$div(class = "table-footnote",
+                      tags$div(class = "table-footnote",
                                "The number of households appears as 10 when there are 10 or less 
              households in a given cell.",
                                tags$br(),

--- a/app/advocates_panel.r
+++ b/app/advocates_panel.r
@@ -26,7 +26,9 @@ advocates_panel <- tabPanel(
                       tags$div(class = "table-footnote","(Dowloads data from above table)"),
                     tags$div(class = "table-footnote",
                                "The number of households appears as 10 when there are 10 or less 
-             households in a given cell.",downloadLink("downloadAll", "Download All Data"))
+             households in a given cell.",
+                               tags$br(),
+                               downloadLink("downloadAll", "Download All Data"))
              ),
              tags$div(class = "bar-graph",
                       plotlyOutput("prop_census"),


### PR DESCRIPTION
This PR:
1. adds a line break to the table footnote, avoiding breaking in the middle of the action link (fixes #120), and
2. updates the label of the download button so that the label will simply say "Download" (fixes #119)