### PR TITLE
Rename the advocates page to the "Explore Your Neighborhood" 

### DIFF
--- a/app/advocates_panel.r
+++ b/app/advocates_panel.r
@@ -2,7 +2,7 @@
 library(shinyWidgets)
 
 advocates_panel <- tabPanel(
-    title = "For Advocates",
+    title = "Explore Your Neighborhood",
     tags$div(class = "main-point",
              "Find Out How Your Neighborhood is Doing"),
     tags$div(class = "sub-point",

--- a/app/home_panel.r
+++ b/app/home_panel.r
@@ -8,7 +8,7 @@ home_panel <- tabPanel(
              tags$div(class = "title",
                       "Housing Choice Voucher in Delaware"),
              actionLink(inputId = "to_advocates_page", 
-                        label = "Check out our Housing Voucher Lookup Tool",
+                        label = "Explore Your Neighborhood",
                         class = "learn-more-button")
     ),
     tags$div(
@@ -120,7 +120,7 @@ home_panel <- tabPanel(
                  "Want to learn more about how your neighborhood is doing?"
         ),
         actionLink(inputId = "to_advocates_page_bottom", 
-                   label = "Check out our Housing Voucher Lookup Tool",
+                   label = "Explore Your Neighborhood",
                    class = "learn-more-button")
     )
 )

--- a/app/server.R
+++ b/app/server.R
@@ -72,6 +72,10 @@ de_summary_table <- geo_data_nogeometry %>%
     group_by(GEOID) %>% 
     mutate(tot = number_reported)
 
+# function to go to the lookup tool
+goto_explore_tab <- function(session){
+    updateNavbarPage(session, inputId = "main_page", selected = "Explore Your Neighborhood")
+}
 
 # Define server logic required to draw a histogram
 shinyServer(function(input, output, session) {
@@ -80,7 +84,7 @@ shinyServer(function(input, output, session) {
         query <- parseQueryString(session$clientData$url_search)
         query1 <- paste(names(query), query, sep = "=", collapse=", ")
         if(query1 == "page=advocates"){
-            updateNavbarPage(session, inputId = "main_page", selected = "For Advocates")
+            goto_explore_tab(session)
         }
     })
     
@@ -264,10 +268,10 @@ shinyServer(function(input, output, session) {
     
     # Observe the click to the advocates page
     observeEvent(input$to_advocates_page, {
-        updateNavbarPage(session, inputId =  "main_page", selected = "For Advocates")
+        goto_explore_tab(session)
     })
     observeEvent(input$to_advocates_page_bottom, {
-        updateNavbarPage(session, inputId =  "main_page", selected = "For Advocates")
+        goto_explore_tab(session)
     })
     
     # Look for a GEOID for a given address (Python)


### PR DESCRIPTION
This PR changes the name of the advocates page to "Explore Your Neighborhood" (fixes #105):

![image](https://user-images.githubusercontent.com/17035406/155601254-5973fc84-5ca3-4c8f-a872-1d1e4d03e54f.png)


The PR also includes a change in the CTA button label to be consistent with this change. The CTA button is labeled "Explore Your Neighborhood":
![image](https://user-images.githubusercontent.com/17035406/155601344-13a48875-9417-43ae-874f-65fccc06fd7e.png)

