### PR TITLE
Fix and reposition the address search bar

### DIFF
--- a/app/advocates_panel.r
+++ b/app/advocates_panel.r
@@ -13,7 +13,9 @@ advocates_panel <- tabPanel(
     tags$div(class = "address-input-container",
              searchInput("address", label = NULL, placeholder = "Enter your address",
                          btnSearch = icon("search")),
-             textOutput("current_GEOID")),
+             tags$div(class = "address-message",
+                      textOutput("address_message"))
+             ),
     leafletOutput("advocmap"),
     tags$div(class = "advoc-container",
              tags$div(class = "advoc-table-container",

--- a/app/scripts/plot_prop_census.R
+++ b/app/scripts/plot_prop_census.R
@@ -50,6 +50,10 @@ plot_prop_census <- function(perc, ids){
         
     }
     
-    return(ggplotly(prop_census_plot, tooltip="text"))
+    out_plot <- ggplotly(prop_census_plot, tooltip="text") %>%
+        plotly_disable_zoom() %>%
+        plotly_hide_modebar()
+    
+    return(out_plot)
 }
 

--- a/app/server.R
+++ b/app/server.R
@@ -256,55 +256,32 @@ shinyServer(function(input, output, session) {
         goto_explore_tab(session)
     })
     
-    # Look for a GEOID for a given address (Python)
+    # Geocode a given address via python when the search is initiated
     found_GEOID <- reactiveValues(ids=vector())
-    observeEvent(input$address_search,
-                 {tryCatch(
-                     {
-                         found_GEOID$ids <- return_geoid(input$address)
-                         output$current_GEOID <-  renderText({found_GEOID$ids})
-                         sub <- shape %>% filter(GEOID %in% (found_GEOID$ids))
-                         #output$result <- renderText({sub$NAMELSAD})
-                         clicked_ids$Clicks <- c(clicked_ids$Clicks, sub$NAMELSAD) # name when clicked, id when unclicked
-                         clicked_ids$Clicks <- unique(clicked_ids$Clicks)
-                         leafletProxy("advocmap") %>% addTiles() %>%
-                             addPolygons(data=sub,
-                                         fillColor = "#b30000",color = "#2b8cbe",opacity = 1,weight=2,
-                                         fillOpacity = 0.8, smoothFactor = 0.5,
-                                         highlight=highlightOptions(fillOpacity = 0.8,
-                                                                    color = "#b30000",
-                                                                    weight = 2,
-                                                                    bringToFront=TRUE),
-                                         label= ~NAMELSAD, layerId = ~NAMELSAD)
-
-                          if (length(clicked_ids$Clicks)>1){
-                             agg_selected <- advoc_table %>% filter(NAMELSAD %in% clicked_ids$Clicks)
-                             agg_receiving<-round((sum(agg_selected$`# Receiving assisstance`)/sum(agg_selected$tot_hh))*100, digits = 2)
-                             agg_30<-round((sum(agg_selected$`# Spending 30%+ of income on rent`)/sum(agg_selected$tot_hh))*100, digits = 2)
-                             agg_50<-round((sum(agg_selected$`# Spending 50%+ of income on rent`)/sum(agg_selected$tot_hh))*100, digits = 2)
-                             output$table_desc <- renderText({paste("Currently selected census tracts has in total <br><b>",agg_receiving,"% </b> of
-                             households receiving Housing Choice Voucher, <br><b>",agg_30,"% </b>
-                             of households spending above 30% of income on rent and <br><b>",agg_50,"% </b> 
-                                   of households spending above 50% of income on rent",  sep = " ")})
-                         }
-                         else{output$table_desc <- renderText({""})}
-                         
-                         output$prop_census <- renderPlotly({
-                             if(input$selectedCensusProp == "30"){
-                                 plot_prop_census(30,clicked_ids$Clicks)
-                             } 
-                             else {
-                                 plot_prop_census(50,clicked_ids$Clicks)
-                             }
-                         })
-                         
-                     },
-                     error = function(cond){
-                         found_GEOID$ids <- "No GEOID found"
-                         output$current_GEOID <-  renderText({found_GEOID$ids})
-                     }
-                 )
-                 })
+    observeEvent(input$address_search, {
+        tryCatch(
+            {
+                found_GEOID$ids <- return_geoid(input$address)
+                
+                current_tract_name <- geo_data %>%
+                    filter(GEOID == found_GEOID$ids) %>%
+                    pull(tract)
+                
+                address_message(paste0("Your census tract is: ", current_tract_name))
+                
+                clicked_ids$Clicks <- c(clicked_ids$Clicks, found_GEOID$ids) # name when clicked, id when unclicked
+                clicked_ids$Clicks <- unique(clicked_ids$Clicks)
+                
+                new_data <- geo_data %>% 
+                    filter(GEOID %in% (clicked_ids$Clicks))
+                update_map(new_data, to_state = "select")
+            },
+            error = function(cond){
+                address_message("No place found. Try formatting your address as: \"411 Legislative Ave, Dover, DE\"")
+            }
+        )
+    }
+    )
     
     output$prop_census <- renderPlotly({
         if(input$selectedCensusProp == "30"){

--- a/app/server.R
+++ b/app/server.R
@@ -287,7 +287,7 @@ shinyServer(function(input, output, session) {
         if(input$selectedCensusProp == "30"){
             plot_prop_census(30, clicked_ids$Clicks)
         } 
-        else {
+        else if(input$selectedCensusProp == "50") {
             plot_prop_census(50, clicked_ids$Clicks)
         }
     })

--- a/app/server.R
+++ b/app/server.R
@@ -81,6 +81,10 @@ goto_explore_tab <- function(session){
 
 # Define server logic required to draw a histogram
 shinyServer(function(input, output, session) {
+    # Reactive value for the message for the address lookup
+    address_message <- reactiveVal("Example: \"411 Legislative Ave, Dover, DE\"")
+    output$address_message <- renderText({ address_message() })
+
     # Observe the URL parameter and route the page to an appropriate tab
     observe({
         query <- parseQueryString(session$clientData$url_search)

--- a/app/server.R
+++ b/app/server.R
@@ -202,15 +202,17 @@ shinyServer(function(input, output, session) {
     output$advocmap <- renderLeaflet({advoc_map})
     clicked_ids <- reactiveValues(Clicks=vector())
     
-    # #if map is clicked, set values
+    # If the map is clicked, update the reactive value
     observeEvent(input$advocmap_shape_click, {
         clicked_tract <- input$advocmap_shape_click
-        clicked_ids$Clicks <- c(clicked_ids$Clicks, clicked_tract$id) # name when clicked, id when unclicked
+        # Add a new selected GEOID to the reactive value
+        clicked_ids$Clicks <- c(clicked_ids$Clicks, clicked_tract$id)
         removePoly <- clicked_ids$Clicks[duplicated(clicked_ids$Clicks)]
         remove <- FALSE
         if(length(removePoly) > 0){
             remove=TRUE
         }
+        # Avoid duplicates in GEOIDs
         clicked_ids$Clicks <- clicked_ids$Clicks[!clicked_ids$Clicks %in% clicked_ids$Clicks[duplicated(clicked_ids$Clicks)]]
 
         if(is.null(clicked_tract))

--- a/app/server.R
+++ b/app/server.R
@@ -242,14 +242,6 @@ shinyServer(function(input, output, session) {
         }
         else{output$table_desc <- renderText({""})}
         
-        output$prop_census <- renderPlotly({
-            if(input$selectedCensusProp == "30"){
-                plot_prop_census(30,clicked_ids$Clicks)
-            } 
-            else {
-                plot_prop_census(50,clicked_ids$Clicks)
-            }
-        })
         
     })
     

--- a/app/server.R
+++ b/app/server.R
@@ -214,7 +214,7 @@ shinyServer(function(input, output, session) {
         }
         # Avoid duplicates in GEOIDs
         clicked_ids$Clicks <- clicked_ids$Clicks[!clicked_ids$Clicks %in% clicked_ids$Clicks[duplicated(clicked_ids$Clicks)]]
-
+        
         if(is.null(clicked_tract))
             return()
         else
@@ -240,9 +240,9 @@ shinyServer(function(input, output, session) {
                              of households spending above 30% of income on rent and <br><b>",agg_50,"% </b> 
                                    of households spending above 50% of income on rent",  sep = " ")})
         }
-        else{output$table_desc <- renderText({""})}
-        
-        
+        else { 
+            output$table_desc <- renderText({""})
+        }
     })
     
     # Observe the click to the advocates page

--- a/app/server.R
+++ b/app/server.R
@@ -205,7 +205,7 @@ shinyServer(function(input, output, session) {
     
     output$advocmap <- renderLeaflet({advoc_map})
     clicked_ids <- reactiveValues(Clicks=vector())
-    
+
     # If the map is clicked, update the reactive value
     observeEvent(input$advocmap_shape_click, {
         clicked_tract <- input$advocmap_shape_click
@@ -219,9 +219,6 @@ shinyServer(function(input, output, session) {
         # Avoid duplicates in GEOIDs
         clicked_ids$Clicks <- clicked_ids$Clicks[!clicked_ids$Clicks %in% clicked_ids$Clicks[duplicated(clicked_ids$Clicks)]]
         
-        if(is.null(clicked_tract))
-            return()
-        else
             if(remove == TRUE){
                 new_data <- geo_data %>% 
                     filter(GEOID %in% (removePoly))
@@ -248,6 +245,8 @@ shinyServer(function(input, output, session) {
             output$table_desc <- renderText({""})
         }
     })
+    
+    
     
     # Observe the click to the advocates page
     observeEvent(input$to_advocates_page, {
@@ -309,10 +308,10 @@ shinyServer(function(input, output, session) {
     
     output$prop_census <- renderPlotly({
         if(input$selectedCensusProp == "30"){
-            plot_prop_census(30,clicked_ids$Clicks)
+            plot_prop_census(30, clicked_ids$Clicks)
         } 
         else {
-            plot_prop_census(50,clicked_ids$Clicks)
+            plot_prop_census(50, clicked_ids$Clicks)
         }
     })
     

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -278,7 +278,24 @@
 
 .address-input-container {
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
+    align-items: flex-start;
+    position: absolute;
+    z-index: 10;
+    margin-left: 4rem;
 }
 
+.address-message {
+    background-color: white;
+    opacity: 0.9;
+    padding: 8px;
+    border-radius: 10px;
+    color: #8a8a8a;
+    margin-left: 1rem;
+}
+
+.form-group {
+    margin-bottom: none;
+    margin: 1rem;
+}
 


### PR DESCRIPTION
This PR includes fixing the address search bar (fixes #128).

The PR also includes:
- Cleanups for reducing duplicate codes and routines
- Re-design of the message field of the address search bar so that it shows (a) an example when there is no input, and (b) shows a census tract when the value is looked up.
- Disable zoom and hide the mode bar from the barplot

Further thoughts: I think it's better if we have a loading spinner on that lookup bar. Currently, there is no feedback after clicking the magnifier icon.