### PR TITLE
Broaden the audience for the renters ("Are you struggling to pay rent?")

### DIFF
--- a/app/home_panel.r
+++ b/app/home_panel.r
@@ -61,8 +61,7 @@ home_panel <- tabPanel(
     tags$div(class = "main-point-container",
              tags$div(class = "main-heading-container", 
                       tags$div(class = "main-point",
-                               "Are you currently paying 30% or more of 
-                               your household income on rent?")
+                               "Are you struggling to pay rent?")
              ),
              tags$div(class = "take-action-container",
                       tags$div(class = "take-action-card-blue",


### PR DESCRIPTION
This PR changes the title of the call-to-action card for the renters, to "Are you struggling to pay rent?" (fixes #132). The new title broadens the audience to anyone who is struggling (not only those with 30% or more rent spending on income).

<img width="661" alt="image" src="https://user-images.githubusercontent.com/17035406/156435222-abd04e6c-25b1-4974-a8d6-c97b61ac30e4.png">
