### PR TITLE
Make the background image responsive for the title 

### DIFF
--- a/app/www/style.css
+++ b/app/www/style.css
@@ -34,7 +34,8 @@
     background-image: url('wilmington.png');
     background-origin: border-box;
     background-position: center;
-    background-repeat: repeat-x;
+    background-repeat: no-repeat;
+    background-size: cover;
 }
 
 .main-point-container {


### PR DESCRIPTION
This PR makes the background image of the title responsive. Now, the background image of the title changes size depending on the window widths (instead of tiling).

Fixes #133 