### PR TITLE
Add a retry to the PR workflow

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -25,11 +25,18 @@ jobs:
         run: docker build -t pullrequestimage . 
       # run the image (but supply the TESTNAME in stead of MASTERNAME, so the 
       # app ends up in a different place.   
-      - name: execute
-        run: >
-          docker run 
-          -e SHINY_ACC_NAME=${{secrets.SHINY_ACC_NAME}} 
-          -e TOKEN=${{secrets.TOKEN}} 
-          -e SECRET=${{secrets.SECRET}} 
-          -e MASTERNAME=${{secrets.TEST_NAME}} 
-          pullrequestimage
+      
+      # Execute
+      - name: Execute
+        uses: nick-fields/retry@v2.4.0
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: >
+            docker run 
+            -e SHINY_ACC_NAME=${{secrets.SHINY_ACC_NAME}} 
+            -e TOKEN=${{secrets.TOKEN}} 
+            -e SECRET=${{secrets.SECRET}} 
+            -e MASTERNAME=${{secrets.TEST_NAME}} 
+            pullrequestimage
+          retry_wait_seconds: 10


### PR DESCRIPTION
Currently, the auto-deployment to shinyapps.io fails intermittently. This PR updates the workflow for the PR so that the action will retry by itself.