### PR TITLE
Fix the main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,8 +37,8 @@ jobs:
             -e SHINY_ACC_NAME=${{secrets.SHINY_ACC_NAME}} 
             -e TOKEN=${{secrets.TOKEN}} 
             -e SECRET=${{secrets.SECRET}} 
-            -e MASTERNAME=${{secrets.TEST_NAME}} 
-            pullrequestimage
+            -e MASTERNAME=${{secrets.MASTER_NAME}} 
+            main
           retry_wait_seconds: 10
 
 


### PR DESCRIPTION
This PR fixes the workflow when merging into the main. #159 introduced a bug where the deployment commands were using the codes from the workflows for PR submissions (see https://github.com/de-data-lab/voucher-eligibility/actions/runs/1924774275).