### PR TITLE
Change the color of the CTA buttons to TI orange

### DIFF
--- a/app/www/style.css
+++ b/app/www/style.css
@@ -251,7 +251,7 @@
 
 
 .learn-more-button {
-    background-color: #F27405;
+    background-color: #ED8B00;
     border-radius: 10px;
     padding: 1rem;
     padding-left: 1.5rem;
@@ -266,12 +266,12 @@
 }
 
 .learn-more-button:hover {
-    background-color: #F27405;
+    background-color: #cb7700;
     color: white;
 }
 
 .learn-more-button:active {
-    background-color: #D96704;
+    background-color: #a96300;
     color: white;
     border: none;
 }


### PR DESCRIPTION
This PR changes the color of the CTA buttons to Tech Impact Orange `#ED8B00`. (fixes #136)

I used this tool https://www.0to255.com/ed8b00 to pick increasingly darker colors for the hover `#cb7700` and active `#a96300` states.