### PR TITLE
Use cards to display main points on the homepage

### DIFF
--- a/app/home_panel.r
+++ b/app/home_panel.r
@@ -64,7 +64,7 @@ home_panel <- tabPanel(
                                "Are you struggling to pay rent?")
              ),
              tags$div(class = "take-action-container",
-                      tags$div(class = "take-action-card-blue",
+                      tags$div(class = "take-action-card blue",
                                tags$div(class = "call-to-action-text", 
                                         "You might qualify for housing assistance"),
                                tags$div(class = "call-to-action-text call-to-action-text-sub",

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -41,10 +41,15 @@
 .main-point-container {
     display: flex;
     flex-direction: column;
+    align-items: center;
     text-align: center;
     background-color: #f5f8ff;
     margin-bottom: 15rem;
     margin-top: 15rem;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 93rem;
+    align-self: center;
     padding: 5rem;
 }
 

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -51,13 +51,14 @@
     max-width: 93rem;
     align-self: center;
     padding: 5rem;
+    padding-top: 10rem;
+    padding-bottom: 10rem;
 }
 
 
 .main-point {
     text-align: center;
     font-size: 3.5rem;
-    margin-top: 5rem;
     margin-bottom: 2rem;
     margin-left: auto;
     margin-right: auto;

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -5,7 +5,7 @@
     font-family: 'Roboto', sans-serif;
 }
 
-.tab-pane .plotly{
+.tab-pane .plotly {
     max-width: 1024px;
     margin-left: auto;
     margin-right: auto;

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -156,28 +156,21 @@
 
 .take-action-container {
     display: flex;
-    justify-content: center;
     flex-direction: column;
+    align-items: center;
 }
 
 .take-action-card {
-    padding: 4rem;
+    padding: 3rem;
     margin: auto;
-    max-width: 100rem;
+    max-width: 63rem;
     display: flex;
     background: #D7F5B5;
-    justify-content: center;
     flex-direction: column;
 }
 
-.take-action-card-blue {
-    padding: 3rem;
-    margin: auto;
-    max-width: 100rem;
-    display: flex;
+.take-action-card.blue {
     background: #CED7F5;
-    justify-content: center;
-    flex-direction: column;
 }
 
 .call-to-action-text {
@@ -197,7 +190,6 @@
 .follow-campaign-list {
     text-align: left;
     font-size: 2rem;
-    max-width: 30em;
     margin-top: 2rem;
     margin-left: auto;
     margin-right: auto;
@@ -209,7 +201,6 @@
 .follow-housing-authorities-list {
     text-align: left;
     font-size: 2rem;
-    max-width: 50rem;
     margin-top: 2rem;
     margin-left: auto;
     margin-right: auto; 


### PR DESCRIPTION
This PR adds cards to display the main points on the homepage (fixes #137). This PR also includes a fix for the issue where the action cards had different widths (#127).

Along the way, I realized that I had max-widths applied to the child elements (lists within the cards). I was wondering why I could not change the widths.

Reminder to self to check the child elements ✅ 