### PR TITLE
Move the citations below the heading

### DIFF
--- a/app/home_panel.r
+++ b/app/home_panel.r
@@ -27,8 +27,6 @@ home_panel <- tabPanel(
                                "Housing Choice Voucher is an effective way 
              to help families and provide better opportunities")
              ),
-             tags$div(class = "main-point--icon",
-                      icon("hand-holding-heart")),
              tags$div(class = "main-point--footnote",
                       "(Source: ", 
                       tags$a(href = "https://www.cbpp.org/research/housing/housing-choice-voucher-program-oversight-and-review-of-legislative-proposals#_ftn2",
@@ -39,7 +37,9 @@ home_panel <- tabPanel(
                              target = "_blank",
                              "CBPP, 2021"),
                       ")"
-             )
+             ),
+             tags$div(class = "main-point--icon",
+                      icon("hand-holding-heart"))
     ),
     tags$div(class = "main-point-container",
              tags$div(class = "main-heading-container", 


### PR DESCRIPTION
This PR moves the citations below the heading (fixes #139). Previously, the citations were at the bottom of the icon.

<img width="1065" alt="image" src="https://user-images.githubusercontent.com/17035406/156638981-58d1fa2f-90d5-4909-b796-a6599074251c.png">
