### PR TITLE
Make the backgrounds of the plots transparent

### DIFF
--- a/app/scripts/plot_counts_counties.R
+++ b/app/scripts/plot_counts_counties.R
@@ -31,6 +31,7 @@ plot_counts_counties <- function(.data, cutoff){
         ylab("Number of families"),
         xlab(""),
         theme_minimal(),
+        theme(panel.background = element_rect(fill='transparent')),
         scale_x_discrete(limits = rev(c("New Castle", "Kent", "Sussex"))),
         scale_y_continuous(limits = c(0, 30000)),
         scale_fill_brewer(palette = "Set2", direction = 1, name = ""),

--- a/app/scripts/plot_prop_census.R
+++ b/app/scripts/plot_prop_census.R
@@ -49,8 +49,7 @@ plot_prop_census <- function(perc, ids){
     }
     
     out_plot <- ggplotly(prop_census_plot, tooltip="text") %>%
-        plotly_disable_zoom() %>%
-        plotly_hide_modebar()
+        format_plotly()
     
     return(out_plot)
 }

--- a/app/scripts/plot_prop_counties.R
+++ b/app/scripts/plot_prop_counties.R
@@ -27,9 +27,7 @@ plot_prop_counties <- function(.data){
     out_plot <- prop_counties_plot %>%
         ggplotly(tooltip = "") %>%
         layout(legend = list(traceorder = "reversed")) %>%
-        plotly_legend_top_right() %>%
-        plotly_disable_zoom() %>%
-        plotly_hide_modebar()
+        format_plotly()
     
     return(out_plot)
 }

--- a/app/scripts/plot_prop_counties.R
+++ b/app/scripts/plot_prop_counties.R
@@ -13,6 +13,7 @@ plot_prop_counties <- function(.data){
                  stat = "identity",
                  width = 0.7) +
         theme_minimal() +
+        theme(panel.background = element_rect(fill='transparent')) +
         geom_text(color = "white") + 
         scale_y_continuous(labels = scales::percent) +
         scale_fill_brewer(palette = "Set2", name = "", direction = -1) + 

--- a/app/scripts/plot_table_desc.R
+++ b/app/scripts/plot_table_desc.R
@@ -75,8 +75,7 @@ plot_table_desc <- function(agg_selected,selected){
     }
     
     out_plot <- ggplotly(table_plot, tooltip = "") %>%
-        plotly_disable_zoom() %>%
-        plotly_hide_modebar()
+        format_plotly()
     
     return(out_plot)
 

--- a/app/scripts/plotly_settings.R
+++ b/app/scripts/plotly_settings.R
@@ -20,3 +20,12 @@ plotly_hide_modebar <- function(p) {
     p %>%
         config(displayModeBar = FALSE)
 }
+
+
+format_plotly <- function(p) {
+    p %>%
+        plotly_legend_top_right() %>%
+        plotly_disable_zoom() %>%
+        plotly_hide_modebar() %>%
+        layout(paper_bgcolor = "transparent")
+}

--- a/app/server.R
+++ b/app/server.R
@@ -133,7 +133,7 @@ shinyServer(function(input, output, session) {
                                 y = 0.95,
                                 yanchor = "top"),
                    margin = list(t = 100)) %>%
-            plotly_hide_modebar()
+            format_plotly()
         
     })
     
@@ -156,9 +156,7 @@ shinyServer(function(input, output, session) {
         }
         current_plot %>% 
             ggplotly(tooltip = "y") %>%
-            plotly_legend_top_right() %>%
-            plotly_disable_zoom() %>%
-            plotly_hide_modebar()
+            format_plotly()
     })
     
     output$prop_counties <- renderPlotly({


### PR DESCRIPTION
This PR makes the backgrounds of the plots transparent (fixes #140). Previously, the backgrounds were white.

To implement, I had to make two changes:
1. I made the background transparent by changing the paper color on plotly `layout()`
2. I used a transparent background on the ggplot side `theme()`

Only changing the bg color on plotly only results in changing the bg color around the chart (bg for titles etc.), but not the bg color within the chart.