### PR TITLE
Add a margin to the title part of the explore tab

### DIFF
--- a/app/advocates_panel.r
+++ b/app/advocates_panel.r
@@ -3,14 +3,15 @@ library(shinyWidgets)
 
 advocates_panel <- tabPanel(
     title = "Explore Your Neighborhood",
-    tags$div(class = "main-point",
-             "Find Out How Your Neighborhood is Doing"),
-    tags$div(class = "sub-point",
-             "Find out what percentage of households in your neighbourhood
+    tags$div(class = "explore-title-container",
+             tags$div(class = "main-point",
+                      "Find Out How Your Neighborhood is Doing"),
+             tags$div(class = "sub-point",
+                      "Find out what percentage of households in your neighbourhood
              are receiving Housing Choice Voucher and
               what percentage of households are spending
-             more than 30% and 50% of their income on rent"),
-    
+             more than 30% and 50% of their income on rent")
+             ),
     tags$div(class = "advoc-container",
              
         tags$div(class = "advoc-table-container",

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -314,3 +314,7 @@
     margin: 1rem;
 }
 
+
+.explore-title-container {
+    margin: 5rem;
+}


### PR DESCRIPTION
This PR adds a margin around the title part of the explore tab (fixes #166). Previously, there was no margin to the title of the explore app, and thus no y-margin was present. This PR wraps the title and the description into a div and adds a uniform margin around it.
