### PR TITLE
Tweak the title of the app

### DIFF
--- a/app/home_panel.r
+++ b/app/home_panel.r
@@ -6,7 +6,7 @@ home_panel <- tabPanel(
     title = "Home",
     tags$div(class = "title-container",
              tags$div(class = "title",
-                      "How is Delaware doing to help families in a housing crisis?"),
+                      "How is Delaware helping families in a housing crisis?"),
              actionLink(inputId = "to_advocates_page", 
                         label = "Explore Your Neighborhood",
                         class = "learn-more-button")


### PR DESCRIPTION
This PR tweaks the title of the app to be: "How is Delaware helping families in a housing crisis?". Fixes #169.