### PR TITLE
Justify the texts showing proportions of serviced renters by converting the plot to a plotly naive

### DIFF
--- a/app/scripts/plot_prop_counties.R
+++ b/app/scripts/plot_prop_counties.R
@@ -1,35 +1,69 @@
 # Plot proportions across counties
 
+str_wrap_br <- function(string, width = 50){
+    paste(
+        strwrap(string,
+                width),
+        collapse = "<br>")
+}
+
 plot_prop_counties <- function(.data){
     prop_counties_data <- .data %>%
         group_by(county_name, labels) %>%
         summarise(count = sum(value, na.rm = TRUE)) %>%
         mutate(prop = count / sum(count))
     
-    prop_counties_plot <- prop_counties_data %>%
-        ggplot(aes(x = county_name, y = prop, fill = labels,
-                   label = paste(scales::percent(prop)))) +
-        geom_bar(position = "fill", 
-                 stat = "identity",
-                 width = 0.7) +
-        theme_minimal() +
-        theme(panel.background = element_rect(fill='transparent')) +
-        geom_text(color = "white") + 
-        scale_y_continuous(labels = scales::percent) +
-        scale_fill_brewer(palette = "Set2", name = "", direction = -1) + 
-        scale_x_discrete(limits = rev(c("New Castle",
-                                        "Kent",
-                                        "Sussex"))) + 
-        ylab("") +
-        xlab("") +
-        ggtitle("Renters Potentially Eligible for Voucher") +
-        coord_flip()
-    
-    out_plot <- prop_counties_plot %>%
-        ggplotly(tooltip = "") %>%
-        layout(legend = list(traceorder = "reversed")) %>%
+    prop_counties_plot <- plot_ly() %>% 
+        add_bars(data = prop_counties_data %>% filter(labels == "Receiving Voucher"),
+                 x = ~prop, y = ~county_name,
+                 marker = list(color = "#66C2A5"),
+                 name = "Receiving Voucher",
+                 text = ~prop,
+                 texttemplate = "%{x:.1%}",
+                 insidetextanchor = "start",
+                 textposition = "inside",
+                 textangle = 0,
+                 hovertemplate = str_wrap_br(
+                     "In %{y} County, %{x:.1%} of the eligible families are receiving a voucher <extra></extra>",
+                     width = 30)
+        ) %>%
+        add_bars(data = prop_counties_data %>% filter(labels == "Not Receiving Voucher"),
+                 x = ~prop, y = ~county_name,
+                 marker = list(color = "#FC8D62"),
+                 name = "Not Receiving Voucher",
+                 text = ~prop,
+                 texttemplate = "%{x:.1%}",
+                 insidetextanchor = "end",
+                 textposition = "inside",
+                 hovertemplate = str_wrap_br(
+                     "In %{y} County, %{x:.1%} of the eligible families are not receiving a voucher <extra></extra>",
+                     width = 30)
+        ) %>%
+        layout(barmode = "stack",
+               xaxis = list(title = "",
+                            showgrid = FALSE,
+                            showline = FALSE,
+                            showticklabels = FALSE,
+                            zeroline = FALSE,
+                            # domain = c(0.15, 1),
+                            tickformat = ".2%"),
+               yaxis = list(title = "",
+                            showgrid = FALSE,
+                            showline = FALSE,
+                            zeroline = FALSE,
+                            categoryorder = "array",
+                            categoryarray = rev(c("New Castle", "Kent", "Sussex"))),
+               legend = list(traceorder = "normal"),
+               margin = list(pad = 15),
+               paper_bgcolor = "transparent") %>% 
         format_plotly()
+    
+    out_plot <- prop_counties_plot 
     
     return(out_plot)
 }
+
+
+
+
 

--- a/app/scripts/plot_prop_counties.R
+++ b/app/scripts/plot_prop_counties.R
@@ -45,7 +45,6 @@ plot_prop_counties <- function(.data){
                             showline = FALSE,
                             showticklabels = FALSE,
                             zeroline = FALSE,
-                            # domain = c(0.15, 1),
                             tickformat = ".2%"),
                yaxis = list(title = "",
                             showgrid = FALSE,

--- a/app/scripts/plotly_settings.R
+++ b/app/scripts/plotly_settings.R
@@ -27,5 +27,6 @@ format_plotly <- function(p) {
         plotly_legend_top_right() %>%
         plotly_disable_zoom() %>%
         plotly_hide_modebar() %>%
-        layout(paper_bgcolor = "transparent")
+        layout(plot_bgcolor = "transparent",
+               paper_bgcolor = "transparent")
 }


### PR DESCRIPTION
This PR justifies the texts showing proportions of serviced renters by converting the plot to a plotly native (fixes #143). 

Note to self that plotly distinguishes `plot_bgcolor` vs. `paper_bgcolor`—I had to set both as transparent to fully remove the background. 

I did not bring back the title since the title will be implemented when fixing #141.