### PR TITLE
Change the call-to-action text of the explore page to "How is your neighborhood doing?"

### DIFF
--- a/app/advocates_panel.r
+++ b/app/advocates_panel.r
@@ -4,8 +4,8 @@ library(shinyWidgets)
 advocates_panel <- tabPanel(
     title = "Explore Your Neighborhood",
     tags$div(class = "explore-title-container",
-             tags$div(class = "main-point",
-                      "Find Out How Your Neighborhood is Doing"),
+             tags$div(class = "main-point bold",
+                      "How is your neighborhood doing?"),
              tags$div(class = "sub-point",
                       "Find out what percentage of households in your neighbourhood
              are receiving Housing Choice Voucher and

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -340,3 +340,7 @@
 .select-county > .form-group {
     margin-left: 1rem;
 }
+
+.bold {
+    font-weight: bold;
+}


### PR DESCRIPTION
This PR changes the CTA of the explore page to a question, "How is your neighborhood doing?". Fixes #144.