### PR TITLE
Use `?page=explore` to navigate to the explore tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ This repo contains all scripts and documentation related to out exploratory work
 ## App
 
 - The main branch is deploeyed at https://nami-techimpact.shinyapps.io/housing-voucher/ 
-- The lookup tool is directly accessible with this URL: https://nami-techimpact.shinyapps.io/housing-voucher/?page=advocates
+- The lookup tool is directly accessible with this URL: https://nami-techimpact.shinyapps.io/housing-voucher/?page=explore
 
 
 ### Development/Testing
 - Each pull request is deployed at https://nami-techimpact.shinyapps.io/housing-voucher-test
-- The lookup tool: https://nami-techimpact.shinyapps.io/housing-voucher-test/?page=advocates
+- The lookup tool: https://nami-techimpact.shinyapps.io/housing-voucher-test/?page=explore
 
 
 ## Project Structure

--- a/app/server.R
+++ b/app/server.R
@@ -90,7 +90,7 @@ shinyServer(function(input, output, session) {
     observe({
         query <- parseQueryString(session$clientData$url_search)
         query1 <- paste(names(query), query, sep = "=", collapse=", ")
-        if(query1 == "page=advocates"){
+        if(query1 == "page=explore"){
             goto_explore_tab(session)
         }
     })


### PR DESCRIPTION
This PR updates the URL parameter ref to the explore tab (`?page=explore`, to be consistent with the title of the tab (fixes #126).

Previously, it was `?page=advocates`.

The PR also includes updates to the README file.