### PR TITLE
Improve tooltips and convert the horizontal bar chart showing counts to Plotly

### DIFF
--- a/app/scripts/plot_counts_counties.R
+++ b/app/scripts/plot_counts_counties.R
@@ -59,6 +59,7 @@ plot_counts_counties <- function(.data, cutoff){
                      width = 30)) %>%
         add_bars(data = plot_data %>% filter(Category == category_label),
                  x = ~count, y = ~county,
+                 marker = list(color = "#FC8D62"),
                  name = str_to_title(family_text),
                  hovertemplate = str_wrap_br(
                      paste0("%{y} County has %{x:,} ", 

--- a/app/scripts/plot_counts_counties.R
+++ b/app/scripts/plot_counts_counties.R
@@ -23,48 +23,69 @@ plot_counts_counties <- function(.data, cutoff){
                   rent_above30 = sum(above30),
                   rent_above50 = sum(above50)) 
     
-    # Number of households spending above 30% and 50% of hh_income on rent.
-    number_county_common_layers <- list(
-        geom_bar(aes(fill = Category),
-                 stat = "identity",
-                 position = position_dodge()),
-        ylab(""),
-        xlab(""),
-        theme_minimal(),
-        theme(panel.background = element_rect(fill='transparent'),
-              panel.grid.major.y = element_blank()),
-        scale_x_discrete(limits = rev(c("New Castle", "Kent", "Sussex"))),
-        scale_y_continuous(limits = c(0, 30000)),
-        scale_fill_brewer(palette = "Set2", direction = 1, name = ""),
-        coord_flip()
-    )
+    # Determine the labels and data depending on the 30/50 cutoff values
     if(cutoff == 30){
-        number_county_30_data <- data_county %>%  
+        family_text <- "rent-burdened famillies"
+        category_label <- "Spending 30%+ income on rent"
+        
+        plot_data <- data_county %>%  
             select(reported_HUD, rent_above30, county) %>%
             dplyr::rename(
                 'Receiving Voucher' = reported_HUD,
                 'Spending 30%+ income on rent' = rent_above30) %>%
             gather(Category, count, -c(county))
-        
-        number_county_30 <- number_county_30_data %>%
-            mutate("Eligible Families" = count) %>%
-            ggplot(aes(x = county, y = `Eligible Families`)) + 
-            number_county_common_layers
-        return(number_county_30)
-    }
+        }
     
     if(cutoff == 50){
-        number_county_50_data <- data_county %>% 
+        family_text <- "severely rent-burdened famillies"
+        category_label <- "Spending 50%+ income on rent"
+        
+        plot_data <- data_county %>% 
             select(reported_HUD, rent_above50, county) %>%
             dplyr::rename(
                 'Receiving Voucher' = reported_HUD,
                 'Spending 50%+ income on rent' = rent_above50) %>%
             gather(Category, count, -c(county))
-        
-        number_county_50 <- number_county_50_data %>%
-            mutate("Eligible Families" = count) %>%
-            ggplot(aes(x = county, y = `Eligible Families`)) +
-            number_county_common_layers
-        return(number_county_50)
     }
+    
+    # Create the output Plotly plot
+    out_plot <- plot_ly() %>%
+        add_bars(data = plot_data %>% filter(Category == "Receiving Voucher"),
+                 x = ~count, y = ~county,
+                 marker = list(color = "#66C2A5"),
+                 name = "Receiving Voucher",
+                 hovertemplate = str_wrap_br(
+                     paste0("In %{y} County, %{x:,} families are receiving a voucher <extra></extra>"),
+                     width = 30)) %>%
+        add_bars(data = plot_data %>% filter(Category == category_label),
+                 x = ~count, y = ~county,
+                 name = str_to_title(family_text),
+                 hovertemplate = str_wrap_br(
+                     paste0("%{y} County has %{x:,} ", 
+                            family_text, " <extra></extra>"),
+                     width = 30)) %>% 
+        layout(xaxis = list(title = "",
+                            showgrid = FALSE,
+                            showline = FALSE,
+                            showticklabels = TRUE,
+                            zeroline = FALSE,
+                            tickformat = ",",
+                            range = list(0, 30000)),
+               yaxis = list(title = "",
+                            showgrid = FALSE,
+                            showline = FALSE,
+                            zeroline = FALSE,
+                            categoryorder = "array",
+                            categoryarray = rev(c("New Castle", "Kent", "Sussex"))),
+               legend = list(traceorder = "normal"),
+               margin = list(pad = 15),
+               paper_bgcolor = "transparent") %>% 
+        format_plotly()
+    
+    return(out_plot)
 }
+
+
+
+
+

--- a/app/server.R
+++ b/app/server.R
@@ -153,9 +153,7 @@ shinyServer(function(input, output, session) {
         else {
             current_plot <- plot_counts_counties(geo_data_nogeometry, 50) 
         }
-        current_plot %>% 
-            ggplotly(tooltip = "y") %>%
-            format_plotly()
+        return(current_plot)
     })
     
     output$prop_counties <- renderPlotly({


### PR DESCRIPTION
This PR improves the tooltips of the horizontal bar chart for counts, by converting it to a full Plotly chart as below (finish fixing #151).


<img width="877" alt="image" src="https://user-images.githubusercontent.com/17035406/157507206-74fedb36-7bf5-46a0-a969-23a6d88e4c3c.png">
<img width="856" alt="image" src="https://user-images.githubusercontent.com/17035406/157507224-d82b387a-6fed-48c9-b59e-84dbd0b26233.png">
<img width="858" alt="image" src="https://user-images.githubusercontent.com/17035406/157507361-333dd5c3-df13-4ca6-9ed7-79b3c5f99cf9.png"><img width="863" alt="image" src="https://user-images.githubusercontent.com/17035406/157507311-6a3348a7-7fa0-4e4a-b7e1-3e368ab63630.png">
