### PR TITLE
Fix the heading level in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This repo contains all scripts and documentation related to out exploratory work
 
 ## Environment Variables
 
-## .Renviron
+### .Renviron
 
 -   `CENSUS_API_KEY`: API key to the Census API
 


### PR DESCRIPTION
This PR fixes the level of the heading for the Renviron file in README.