### PR TITLE
Move the JS for the logo into the footer to remove the empty element in the navbar

### DIFF
--- a/app/ui.R
+++ b/app/ui.R
@@ -17,7 +17,7 @@ navbarPage(
     advocates_panel,
     methods_panel,
     footer = tags$div(class = "footer",
-                      includeHTML("footer.html")),
-    tags$script(src = "show_logo.js")
+                      includeHTML("footer.html"),
+                      tags$script(src = "show_logo.js"))
 )
 


### PR DESCRIPTION
This PR moves the JS rendering the logo to the footer in the `navbarPage` to remove the empty element in the navbar. Fixes #201 