### PR TITLE
Fix the tooltip breaks via tidying and manually setting up tooltip texts

### DIFF
--- a/app/advocates_panel.r
+++ b/app/advocates_panel.r
@@ -53,7 +53,8 @@ advocates_panel <- tabPanel(
                  ),
                  tags$div(class = "explore-bar-container",
                           tags$div(class = "bar-graph",
-                                   "% of Households receiving vouchers and spending 30%+ income and 50%+ income on rent",
+                                   tags$div(class = "explore-bar-title",
+                                            "Percent of families that are:"),
                                    plotlyOutput("table_desc_plot")
                           ),
                           htmlOutput("table_desc")

--- a/app/advocates_panel.r
+++ b/app/advocates_panel.r
@@ -59,7 +59,6 @@ advocates_panel <- tabPanel(
                           htmlOutput("table_desc")
                  ),
                  tags$div(class = "bar-graph",
-                          #textOutput("bar_title"),             
                           selectInput("selectedCensusProp", 
                                            label = NULL,
                                            choices = c("Rent burdened - % Household spending 30%+ income on rent" = "30",

--- a/app/scripts/plot_table_desc.R
+++ b/app/scripts/plot_table_desc.R
@@ -40,12 +40,6 @@ recode_scheme <- c("receiving" = "Receiving Voucher",
                    "spending_50" = "Spending 50%+ of income on rent")
 
 plot_table_desc <- function(agg_selected, is_selected){
-    # Label for all census tracts
-    txt_all <- paste0("For all Delaware census tracts, %{x}% of the households %{y}")
-    
-    # Label for selected census tracts
-    txt_selected <- paste0("For all selected census tracts, %{x}% of the households %{y}")
-    
     # Prepare a table for All Delaware
     # If no tracts are selected, return all Delaware 
     all_delaware_data <- to_plotly_data(advoc_table)

--- a/app/scripts/plot_table_desc.R
+++ b/app/scripts/plot_table_desc.R
@@ -5,87 +5,120 @@ library(plotly)
 library(sf)
 library(RColorBrewer)
 
+# Function to get the data shaped for plotly
+to_plotly_data <- function(.data){
+    # If no tracts are selected, return all Delaware 
+    .data <- .data %>% 
+        group_by() %>%
+        summarise(across(
+            c(receiving = `# Receiving assisstance`,
+              spending_30 = `# Spending 30%+ of income on rent`,
+              spending_50 = `# Spending 50%+ of income on rent`,
+              tot_hh),
+            ~sum(.)
+        ))
+    
+    # Get the percentage and drop the total counts
+    .data <- .data %>%
+        mutate(across(-tot_hh,
+                      ~(. / tot_hh))) %>%
+        select(-tot_hh)
+    
+    # Round the percentage 
+    .data <- .data %>%
+        mutate(across(.fns = ~round(. * 100, 2)))
+    
+    # Pivot to a long format
+    .data <- .data %>%
+        pivot_longer(everything(), names_to = "info_type", values_to = "pct")
+    
+    return(.data)
+}
+
+recode_scheme <- c("receiving" = "Receiving Voucher",
+                   "spending_30" = "Spending 30%+ of income on rent",
+                   "spending_50" = "Spending 50%+ of income on rent")
+
 plot_table_desc <- function(agg_selected, is_selected){
-    # Define labels
-    info_type <- c("Receiving Vouchers",
-                   "Spending 30%+ income on rent",
-                   "Spending 50%+ income on rent")
-    # Create table
-    tot <- c(0,0,0)
-    selected <- c(0,0,0)
-    table_df <- data.frame(info_type, tot, selected)
-    
     # Label for all census tracts
-    txt_all <- str_wrap_br(
-        paste0("For all Delaware census tracts, %{x}% of the households %{y} <extra></extra>"),
-        width = 30)
+    txt_all <- paste0("For all Delaware census tracts, %{x}% of the households %{y}")
+    
     # Label for selected census tracts
-    txt_selected <- str_wrap_br(
-        paste0("For all selected census tracts, %{x}% of the households %{y} <extra></extra>"),
-        width = 30)
+    txt_selected <- paste0("For all selected census tracts, %{x}% of the households %{y}")
     
-    # If not tract is selected prepare a Delaware table 
-    if(!is_selected){
-        # If no tracts are selected, return all Delaware 
-        table_df[1,2] <- round((sum(advoc_table$`# Receiving assisstance`) / sum(advoc_table$tot_hh)) * 100, digits = 2)
-        table_df[2,2] <- round((sum(advoc_table$`# Spending 30%+ of income on rent`) / sum(advoc_table$tot_hh)) * 100, digits = 2)
-        table_df[3,2] <- round((sum(advoc_table$`# Spending 50%+ of income on rent`) / sum(advoc_table$tot_hh)) * 100, digits = 2)
-        
-        table_plot_data <- table_df %>% 
-            dplyr::rename(
-                'All Census Tracts'= tot
-            ) %>%
-            gather(Category, count, -c(info_type))
-    }
+    # Prepare a table for All Delaware
+    # If no tracts are selected, return all Delaware 
+    all_delaware_data <- to_plotly_data(advoc_table)
     
+    # Add a category column indicating the grouping level
+    all_delaware_data <- all_delaware_data %>% 
+        mutate(category = "All Census Tracts")
+    
+    # Add labels for the plotly
+    all_delaware_data <- all_delaware_data %>% 
+        mutate(info_type_label = recode(info_type, !!!recode_scheme)) %>%
+        mutate(plotly_label = str_glue(
+            "In all Delaware, {pct}% of the households
+                are {str_to_lower(info_type_label)} "))
+    
+    # If no plot is selected, get the all Delaware
+    table_plot_data <- all_delaware_data
+    
+
     if (is_selected){
-        table_df[1,3] <- round((sum(agg_selected$`# Receiving assisstance`) / sum(agg_selected$tot_hh)) * 100, digits = 2)
-        table_df[2,3] <- round((sum(agg_selected$`# Spending 30%+ of income on rent`) / sum(agg_selected$tot_hh)) * 100, digits = 2)
-        table_df[3,3] <- round((sum(agg_selected$`# Spending 50%+ of income on rent`) / sum(agg_selected$tot_hh)) * 100, digits = 2)
+        # Format data and add a category column
+        selected_data <- to_plotly_data(agg_selected) %>% 
+            mutate(category = "Selected Census Tracts")
         
-        table_df[1,2] <- round((sum(advoc_table$`# Receiving assisstance`) / sum(advoc_table$tot_hh)) * 100, digits = 2)
-        table_df[2,2] <- round((sum(advoc_table$`# Spending 30%+ of income on rent`) / sum(advoc_table$tot_hh)) * 100, digits = 2)
-        table_df[3,2] <- round((sum(advoc_table$`# Spending 50%+ of income on rent`) / sum(advoc_table$tot_hh)) * 100, digits = 2)
+        # Add labels for the plotly
+        selected_data <- selected_data %>% 
+            mutate(info_type_label = recode(info_type, !!!recode_scheme)) %>%
+            mutate(plotly_label = str_glue(
+                "In the selected census tracts, {pct}% of the households
+                are {str_to_lower(info_type_label)} "))
         
-        table_plot_data <- table_df %>% 
-            dplyr::rename(
-                'All Census Tracts' = tot,
-                'Selected Census Tracts' = selected
-            ) %>%
-            gather(Category, count, -c(info_type))
+        table_plot_data <- all_delaware_data %>% 
+            bind_rows(selected_data)
     }
     
+    # Insert line breaks to the plotly label
+    table_plot_data <- table_plot_data %>% 
+        rowwise() %>%
+        mutate(plotly_label = str_wrap_br(plotly_label, width = 50)) %>%
+        ungroup()
+
     # For both conditions, we need All Delaware bars
     table_plot <- plot_ly() %>% 
-        add_bars(data = table_plot_data %>% filter(Category == 'All Census Tracts'),
-                 x = ~count, y = ~info_type,
+        add_bars(data = table_plot_data %>% filter(category == 'All Census Tracts'),
+                 x = ~pct, y = ~info_type_label,
                  marker = list(color = "#66C2A5"),
                  name = "All Census Tracts",
-                 text = ~count,
+                 text = ~pct,
                  texttemplate = "%{x}%",
                  insidetextanchor = "end",
                  textposition = "outside",
                  textangle = 0,
-                 hovertemplate = txt_all)
+                 hovertext = ~plotly_label,
+                 hoverinfo = "text")
     
     # If a tract is selected, add selected bars
     if(is_selected){
         table_plot <- table_plot %>%
-            add_bars(data = table_plot_data %>% filter(Category == 'Selected Census Tracts'),
-                     x = ~count, y = ~info_type,
+            add_bars(data = table_plot_data %>% filter(category == 'Selected Census Tracts'),
+                     x = ~pct, y = ~info_type_label,
                      marker = list(color = "#FC8D62"),
                      name = "Selected Census Tracts",
-                     text = ~count,
+                     text = ~pct,
                      texttemplate = "%{x}%",
                      insidetextanchor = "end",
                      textposition = "outside",
                      textangle = 0,
-                     hovertemplate = txt_selected
-            )
+                     hovertext = ~plotly_label,
+                     hoverinfo = "text")
     }
     
     # Calculate the maximum value of x axis, used for calculating x range
-    xmax <- max(table_df$tot) * 1.50
+    xmax <- max(table_plot_data$pct) * 1.50
     
     # Update layouting
     table_plot <- table_plot %>%

--- a/app/scripts/plot_table_desc.R
+++ b/app/scripts/plot_table_desc.R
@@ -52,7 +52,7 @@ plot_table_desc <- function(agg_selected, is_selected){
     all_delaware_data <- all_delaware_data %>% 
         mutate(info_type_label = recode(info_type, !!!recode_scheme)) %>%
         mutate(plotly_label = str_glue(
-            "In all Delaware, {pct}% of the households
+            "In all Delaware, {pct}% of the families
                 are {str_to_lower(info_type_label)} "))
     
     # If no plot is selected, get the all Delaware
@@ -68,7 +68,7 @@ plot_table_desc <- function(agg_selected, is_selected){
         selected_data <- selected_data %>% 
             mutate(info_type_label = recode(info_type, !!!recode_scheme)) %>%
             mutate(plotly_label = str_glue(
-                "In the selected census tracts, {pct}% of the households
+                "In the selected census tracts, {pct}% of the families
                 are {str_to_lower(info_type_label)} "))
         
         table_plot_data <- all_delaware_data %>% 

--- a/app/server.R
+++ b/app/server.R
@@ -367,7 +367,7 @@ shinyServer(function(input, output, session) {
         return(output_table)
     }, align='ccccc')
     
-    output$table_desc_plot <- renderPlotly({plot_table_desc("",FALSE)})
+    output$table_desc_plot <- renderPlotly({plot_table_desc("", FALSE)})
     output$table_desc <- renderText({"Select census tracts"})
     output$bar_title <- renderText({"% Household Spending 30%+ of income on rent (for All Census Tracts)"})
     

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -166,7 +166,7 @@
 }
 
 .bar-graph {
-    margin: 4rem;
+    width: 90%;
 }
 
 .table-footnote {

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -160,6 +160,11 @@
     width: 100%;
 }
 
+.explore-bar-title {
+    align-self: start;
+    font-weight: bold;
+}
+
 .bar-graph {
     margin: 4rem;
 }


### PR DESCRIPTION
This PR fixes the issue of the tooltips wrapping weirdly (fixes #221).

The root of the problem was that the wrapping function was applied at the stage of the text template. The wrapping widths did not carry over to the rendered text, and thus the text was not wrapping correctly.

This PR fixes this issue by manually setting up the tooltip texts.

Along the way, I converted non-tidy scripts to tidy codes in hopes of increasing the readability of the code.

This PR also includes small styling changes for the title of the plot (fixes #227).

Screenshot:
![image](https://user-images.githubusercontent.com/17035406/159567490-02c6b58d-eac5-434a-8a7f-5eec9b986e90.png)
