### PR TITLE
Avoid overlapping labels on the explore page

### DIFF
--- a/app/scripts/plot_prop_census.R
+++ b/app/scripts/plot_prop_census.R
@@ -2,6 +2,7 @@
 
 plot_prop_census <- function(perc, ids){
     
+    # Set colors
     hex_default <- "#66C2A5"
     hex_selected <- "#FC8D62"
     

--- a/app/scripts/plot_prop_census.R
+++ b/app/scripts/plot_prop_census.R
@@ -71,8 +71,7 @@ plot_prop_census <- function(perc, ids){
             annotate("text",
                      label = selected_label,
                      x = selected_average_rank,
-                     y = selected_label_position,
-                     vjust = "inward", hjust = "inward")
+                     y = selected_label_position)
         )
     }
     

--- a/app/scripts/plot_prop_census.R
+++ b/app/scripts/plot_prop_census.R
@@ -71,7 +71,7 @@ plot_prop_census <- function(perc, ids){
             annotate("text",
                      label = selected_label,
                      x = selected_average_rank,
-                     y = 30,
+                     y = selected_label_position,
                      vjust = "inward", hjust = "inward")
         )
     }
@@ -98,7 +98,7 @@ plot_prop_census <- function(perc, ids){
                               families are {burden_label}"),
                      width = 20),
                  x = average_rank,
-                 y = labl_position) +
+                 y = overall_label_position) +
         scale_fill_manual("legend", values = c("1" = hex_selected,
                                                "0" = hex_default)) +
         scale_x_discrete(expand = expansion(mult = .1)) +

--- a/app/scripts/plot_prop_census.R
+++ b/app/scripts/plot_prop_census.R
@@ -39,6 +39,11 @@ plot_prop_census <- function(perc, ids){
         filter(row_number() == average_rank) %>%
         pull(GEOID)
     
+    # Get the max y position 
+    max_y <- selected_table[[target_var]] %>% max()
+    overall_label_position <- max_y - max_y/4
+    selected_label_position <- max_y - max_y/1.5
+    
     # Prepare a list of additional geoms for the selected tracts (if none, blank)
     selected_geoms <- list()
     if(length(ids) > 0){
@@ -71,9 +76,6 @@ plot_prop_census <- function(perc, ids){
         )
     }
     
-    # Get the max y position 
-    max_y <- selected_table[[target_var]] %>% max()
-    labl_position <- max_y - max_y/4
     
     prop_census_plot <- selected_table %>%
         ggplot(aes(x = GEOID,


### PR DESCRIPTION
This PR makes the y-position of the label for the selected census tracts responsive to the maximum value of y, thus avoiding overlapping labels. Fixes #240 

<img width="707" alt="image" src="https://user-images.githubusercontent.com/17035406/159963096-92bd4283-640e-42cc-a7ef-ecc39d01b130.png">

<img width="725" alt="image" src="https://user-images.githubusercontent.com/17035406/159963118-94728da8-daad-44b8-b712-2e04ac824d7e.png">
