### PR TITLE
Improve the description for the vertical bar chart

### DIFF
--- a/app/advocates_panel.r
+++ b/app/advocates_panel.r
@@ -56,18 +56,27 @@ advocates_panel <- tabPanel(
                                    tags$div(class = "explore-bar-title",
                                             "Percent of families that are:"),
                                    plotlyOutput("table_desc_plot")
-                          ),
-                          htmlOutput("table_desc")
+                          )
+
                  ),
+                 tags$div(class = "explore-description-container",
+                          tags$div(class = "hbar-description-container",
+                                   textOutput("h_bar_description"),
+                                   tags$span(class = "explore-select-input",
+                                             selectInput("selectedCensusProp", 
+                                                         label = NULL,
+                                                         choices = c("30% of their income on rent" = "30",
+                                                                     "50% of their income on rent" = "50"),
+                                                         selected = "30", 
+                                                         width = 260))
+                          ),
+                          textOutput("h_bar_last_sentence"),
+                          ),
                  tags$div(class = "bar-graph",
-                          selectInput("selectedCensusProp", 
-                                           label = NULL,
-                                           choices = c("Rent burdened - % Household spending 30%+ income on rent" = "30",
-                                                       "Severely rent-burdened % Household spending 50%+ income on rent" = "50"),
-                                           selected = "30",
-                                           width = 800),
-                          "The plot below shows % Households for all Census Tract",
                           plotlyOutput("prop_census")
+                 ),
+                 tags$div(class = "hbar-description-container",
+                          htmlOutput("table_desc")
                  ),
                  tags$div(class = "advoc-table-container",
                           tags$div(class = "advoc-table",

--- a/app/scripts/plot_prop_census.R
+++ b/app/scripts/plot_prop_census.R
@@ -53,7 +53,7 @@ plot_prop_census <- function(perc, ids){
         selected_average_rank <- which.min(abs(selected_table[[target_var]] - selected_average))
 
         # Set the label for the selected tracts
-        selected_label <- str_glue("In the selected tracts, {selected_average_rounded}% 
+        selected_label <- str_glue("In the selected communities, {selected_average_rounded}% 
                                    of families are {burden_label}") %>% 
             str_wrap(width = 20)
         

--- a/app/server.R
+++ b/app/server.R
@@ -267,7 +267,6 @@ shinyServer(function(input, output, session) {
     })
     
     
-    
     # Observe the click to the advocates page
     observeEvent(input$to_advocates_page, {
         goto_explore_tab(session)
@@ -385,7 +384,7 @@ shinyServer(function(input, output, session) {
       print(removePoly)
       remove <- FALSE
       if(length(removePoly) > 0){
-        remove=TRUE
+        remove <- TRUE
       }
       if(remove == TRUE){
         new_data <- geo_data %>% 
@@ -395,5 +394,4 @@ shinyServer(function(input, output, session) {
         output$table_desc_plot <- renderPlotly({plot_table_desc("",FALSE)})
       }
     })
-    
 })

--- a/app/server.R
+++ b/app/server.R
@@ -309,38 +309,6 @@ shinyServer(function(input, output, session) {
                 address_message("No place found. Try formatting your address as: \"411 Legislative Ave, Dover, DE\"")
             }
         )
-        
-        # Generate the description string
-        if (length(clicked_ids$Clicks)>0){
-            agg_selected <- advoc_table %>%
-                filter(GEOID %in% clicked_ids$Clicks)
-            
-            agg_notselected <- advoc_table %>% 
-                filter(!(GEOID %in% clicked_ids$Clicks))
-            
-            agg_receiving <- round((sum(agg_selected$`# Receiving assisstance`) / sum(agg_selected$tot_hh)) * 100, digits = 2)
-            agg_30 <- round((sum(agg_selected$`# Spending 30%+ of income on rent`) / sum(agg_selected$tot_hh)) * 100, digits = 2)
-            agg_50 <- round((sum(agg_selected$`# Spending 50%+ of income on rent`) / sum(agg_selected$tot_hh)) * 100, digits = 2)
-            
-            n_above_receving <- agg_notselected %>% filter(`# Receiving assisstance`>agg_receiving) %>% nrow
-            n_above_30 <- agg_notselected %>% filter(`# Spending 30%+ of income on rent`>agg_30) %>% nrow
-            n_above_50<- agg_notselected %>% filter(`# Spending 50%+ of income on rent`>agg_50) %>% nrow
-            n_below_receving <- agg_notselected %>% filter(`# Receiving assisstance`<agg_receiving) %>% nrow
-            n_below_30 <- agg_notselected %>% filter(`# Spending 30%+ of income on rent`<agg_30) %>% nrow
-            n_below_50 <- agg_notselected %>% filter(`# Spending 50%+ of income on rent`<agg_50) %>% nrow
-            output$table_desc <- renderText({paste("Currently selected census tracts has in total: <br><br><b>",agg_30,"% </b>
-                             of households spending above 30% of income on rent <br><font color=\"#43a2ca\"><i>(<b>",n_above_30," 
-                             </b>census tracts are spending above 30% of income on rent and <br><b>",n_below_30,
-                                                   " </b>census tracts are spending above 30% of income on rent)</i></font>, <br><br><b>",agg_50,"% </b> 
-                                   of households spending above 50% of income on rent <br><font color=\"#43a2ca\"><i>(<b>",n_above_50," 
-                             </b>census tracts are spending above 50% of income on rent and <br><b>",n_below_50,
-                                                   " </b>census tracts are spending above 50% of income on rent)</i></font>,<br><br>",agg_receiving,"% </b> of
-                             households receiving Housing Choice Voucher <br><font color=\"#43a2ca\"><i>(<b>",n_above_receving," 
-                             </b>census tracts are receving higher number of vouchers and <br><b>",n_below_receving,
-                                                   " </b>census tracts are receving lower number of vouchers)</i></font><br><b>",  sep = " ")})
-            output$table_desc_plot <- renderPlotly({plot_table_desc(agg_selected,TRUE)})
-        }
-        
     }
     )
     

--- a/app/server.R
+++ b/app/server.R
@@ -70,7 +70,6 @@ de_summary_table <- geo_data_nogeometry %>%
            "program_label", "program", "sub_program", "name", "GEOID",
            "rent_per_month", "hh_income", "person_income", 
            "spending_per_month","number_reported") %>%
-    group_by(GEOID) %>% 
     mutate(tot = number_reported)
 
 # function to go to the lookup tool

--- a/app/server.R
+++ b/app/server.R
@@ -239,7 +239,6 @@ shinyServer(function(input, output, session) {
         if (length(clicked_ids$Clicks)>0){
             agg_selected <- advoc_table %>% 
                 filter(GEOID %in% clicked_ids$Clicks)
-            glimpse(agg_selected)
             agg_notselected <- advoc_table %>% 
                 filter(!(GEOID %in% clicked_ids$Clicks))
             #print(length(agg_selected$GEOID))

--- a/app/server.R
+++ b/app/server.R
@@ -322,16 +322,6 @@ shinyServer(function(input, output, session) {
         }
     })
     
-    output$bar_title <- 
-      renderText({
-        if(input$selectedCensusProp == "30"){
-            "% Household Spending 30%+ of income on rent (for All Census Tracts)"
-      }
-      if(input$selectedCensusProp == "50"){
-          "% Household Spending 50%+ of income on rent (for All Census Tracts)"
-      }
-    })
-    
     output$advoc_table <- renderTable({
         output_table <- advoc_table %>% 
             filter(GEOID %in% clicked_ids$Clicks) %>%  

--- a/app/server.R
+++ b/app/server.R
@@ -232,11 +232,16 @@ shinyServer(function(input, output, session) {
             update_map(new_data, to_state = "select",addr=FALSE,latt=NA,long=NA)
             
         }
+    })
+    
+    # Observe the selected census tracts
+    observe({
         if (length(clicked_ids$Clicks)>0){
             agg_selected <- advoc_table %>% 
                 filter(GEOID %in% clicked_ids$Clicks)
+            glimpse(agg_selected)
             agg_notselected <- advoc_table %>% 
-              filter(!(GEOID %in% clicked_ids$Clicks))
+                filter(!(GEOID %in% clicked_ids$Clicks))
             #print(length(agg_selected$GEOID))
             #print(length(agg_notselected$GEOID))
             agg_receiving <- round((sum(agg_selected$`# Receiving assisstance`) / sum(agg_selected$tot_hh)) * 100, digits = 2)
@@ -251,19 +256,63 @@ shinyServer(function(input, output, session) {
             output$table_desc <- renderText({paste("Currently selected census tracts has in total: <br><br><b>",agg_30,"% </b>
                              of households spending above 30% of income on rent <br><font color=\"#43a2ca\"><i>(<b>",n_above_30," 
                              </b>census tracts are spending above 30% of income on rent and <br><b>",n_below_30,
-                             " </b>census tracts are spending above 30% of income on rent)</i></font>, <br><br><b>",agg_50,"% </b> 
+                                                   " </b>census tracts are spending above 30% of income on rent)</i></font>, <br><br><b>",agg_50,"% </b> 
                                    of households spending above 50% of income on rent <br><font color=\"#43a2ca\"><i>(<b>",n_above_50," 
                              </b>census tracts are spending above 50% of income on rent and <br><b>",n_below_50,
-                             " </b>census tracts are spending above 50% of income on rent)</i></font>,<br><br>",agg_receiving,"% </b> of
+                                                   " </b>census tracts are spending above 50% of income on rent)</i></font>,<br><br>",agg_receiving,"% </b> of
                              households receiving Housing Choice Voucher <br><font color=\"#43a2ca\"><i>(<b>",n_above_receving," 
                              </b>census tracts are receving higher number of vouchers and <br><b>",n_below_receving,
-                             " </b>census tracts are receving lower number of vouchers)</i></font><br><b>",  sep = " ")})
+                                                   " </b>census tracts are receving lower number of vouchers)</i></font><br><b>",  sep = " ")})
             output$table_desc_plot <- renderPlotly({plot_table_desc(agg_selected,TRUE)})
+            
+            # Update descriptions
+            n_selected <- clicked_ids$Clicks %>% length()
+            output$h_bar_region <- renderText({str_glue("the selected {n_selected} tracts")})
+            # Show percent for the selected trats
+            if(input$selectedCensusProp == "30"){
+                h_bar_pct <- DE_pct$rent_30
+                target_var <- sym("% Spending 30%+ of income on rent")
+            } 
+            if(input$selectedCensusProp == "50"){
+                h_bar_pct <- DE_pct$rent_50
+                target_var <- sym("% Spending 50%+ of income on rent")
+            } 
+            h_bar_region <- str_glue("the selected communities")
+            selected_pct_avg <- agg_selected %>%
+                group_by() %>%
+                summarise(avg = mean(!!target_var)) %>%
+                unlist()
+            h_bar_pct <- selected_pct_avg
+            
+            # Calculate the percentile from the ECDF
+            selected_percentile <- ecdf(advoc_table$`% Spending 30%+ of income on rent`)(selected_pct_avg)
+            rendered_percentile <- (selected_percentile * 100) %>% round(1)
+            output$h_bar_last_sentence <- renderText({
+                str_glue("That is more than {rendered_percentile}% of
+                         communities in Delaware.")
+                })
         }
+        # If no census tracts are selected, show information about all Delaware
         else { 
-            output$table_desc <- renderText({"Select census tracts"})
+            if(input$selectedCensusProp == "30"){
+                h_bar_pct <- DE_pct$rent_30
+            } 
+            if(input$selectedCensusProp == "50"){
+                h_bar_pct <- DE_pct$rent_50
+            } 
+            # Set the label for the region
+            h_bar_region <- "Delaware"
+            output$h_bar_last_sentence <- renderText({""})
             output$table_desc_plot <- renderPlotly({plot_table_desc(agg_selected,FALSE)})
+            output$table_desc <- renderText({"Select census tracts"})
         }
+        # Round the percentage
+        h_bar_pct_rounded <- h_bar_pct %>% round(1)
+        # Render the description text 
+        output$h_bar_description <- renderText({
+            str_glue("{h_bar_pct_rounded}% of families in {h_bar_region} spent at 
+                         least ")
+        })
     })
     
     
@@ -333,8 +382,6 @@ shinyServer(function(input, output, session) {
     }, align='ccccc')
     
     output$table_desc_plot <- renderPlotly({plot_table_desc("", FALSE)})
-    output$table_desc <- renderText({"Select census tracts"})
-    output$bar_title <- renderText({"% Household Spending 30%+ of income on rent (for All Census Tracts)"})
     
     # Observe for the clicking the "Clear All" button
     observeEvent(input$clear, {

--- a/app/server.R
+++ b/app/server.R
@@ -72,6 +72,15 @@ de_summary_table <- geo_data_nogeometry %>%
            "spending_per_month","number_reported") %>%
     mutate(tot = number_reported)
 
+# Summary table for 30 and 50 
+DE_pct <- advoc_table %>% 
+    group_by() %>%
+    summarise(across(c(receiving_assistance = `% Receiving assisstance`,
+                       rent_30 = `% Spending 30%+ of income on rent`,
+                       rent_50 = `% Spending 50%+ of income on rent`),
+                     ~round(mean(.), 1))) %>% 
+    as.list()
+
 # function to go to the lookup tool
 goto_explore_tab <- function(session){
     updateNavbarPage(session, inputId = "main_page", selected = "Explore Your Neighborhood")

--- a/app/server.R
+++ b/app/server.R
@@ -346,6 +346,7 @@ shinyServer(function(input, output, session) {
     output$table_desc <- renderText({"Select census tracts"})
     output$bar_title <- renderText({"% Household Spending 30%+ of income on rent (for All Census Tracts)"})
     
+    # Observe for the clicking the "Clear All" button
     observeEvent(input$clear, {
       removePoly <- clicked_ids$Clicks
       clicked_ids$Clicks<-vector()

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -107,6 +107,7 @@
     padding: 1rem;
     min-height: 35rem;
     margin-bottom: 1rem;
+    margin-top: 10rem;
     text-align: center;
 }
 
@@ -158,8 +159,14 @@
     flex-direction: column;
     align-items: center;
     width: 100%;
+    margin-bottom: 4rem;
 }
 
+.explore-description-container {
+    margin-top: 4rem;
+    margin-bottom: 1rem;
+    font-size: large;
+}
 .explore-bar-title {
     align-self: start;
     font-weight: bold;
@@ -390,6 +397,24 @@
     margin-top: 5px;
 }
 
+/* Inline select iput for the explore page*/
+.explore-select-input .selectize-input.full {
+    border: none;
+    background-color: transparent;
+    border-bottom-style: solid ;
+    border-bottom-width: 1px;
+    border-color: grey;
+    border-radius: 0;
+    text-align: left;
+    margin-top: 5px;
+    
+}
+
+.hbar-description-container {
+    align-items: center;
+    display: flex;
+}
+
 .form-group {
     margin-bottom: 0!important;
 }
@@ -417,10 +442,5 @@
 
 .methods-container {
     max-width: 70rem;
-    margin: auto;
-}
-
-#table_desc {
-    min-height: 10rem;
     margin: auto;
 }


### PR DESCRIPTION
This PR improves the description for the vertical bar chart by:

1. adding an in-line dropdown menu
2. describing the percentile rank for the selected tracts (used eCDF for estimation)

This PR also includes small style changes and reordering of the elements on the explore page. 

Fixes #219 


## Screenshots

<img width="790" alt="image" src="https://user-images.githubusercontent.com/17035406/160172911-2e41f24f-b687-480d-9783-69abb7dd1eb5.png">


<img width="846" alt="image" src="https://user-images.githubusercontent.com/17035406/160172968-6e21c94c-e49f-4fef-b89f-8aa7bec3a9ec.png">


<img width="1341" alt="image" src="https://user-images.githubusercontent.com/17035406/160173078-8b20b284-ec09-4a1f-aad0-487a4a44cf7c.png">
