### PR TITLE
Add CTA to the explore page

### DIFF
--- a/app/CTA.html
+++ b/app/CTA.html
@@ -1,0 +1,55 @@
+<div class="main-point-container">
+          <div class="main-heading-container">
+            <div class="main-point">Are you struggling to pay rent?</div>
+          </div>
+          <div class="take-action-container">
+            <div class="take-action-card blue">
+              <div class="call-to-action-text">You might qualify for housing assistance</div>
+              <div class="call-to-action-text call-to-action-text-sub">Get in touch with your local housing authority</div>
+              <ul class="follow-housing-authorities-list">
+                <li>
+                  Wilminton:
+                  <a href="https://whadelaware.org/" target="_blank">Wilmington Housing Authority</a>
+                </li>
+                <li>
+                  Dover:
+                  Dover Housing Authority, (302) 678-1965
+                </li>
+                <li>
+                  Newark:
+                  <a href="https://newarkhousingauthority.net/" target="_blank">Newark Housing Authority</a>
+                </li>
+                <li>
+                  New Castle County (outside Wilmington &amp; Newark):
+                  <a href="https://nccde.org/467/Housing-Choice-Voucher-HCV-Program" target="_blank">New Castle County Department of Community Services</a>
+                </li>
+                <li>
+                  Kent &amp; Sussex Counties:
+                  <a href="http://www.destatehousing.com/Renters/renters.php" target="_blank">Delaware State Housing Authority (DSHA)</a>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        
+        
+        <div class="main-point-container">
+          <div class="main-heading-container">
+            <div class="main-point">Interested in doing something about the housing crisis in Delaware?</div>
+          </div>
+          <div class="take-action-container">
+            <div class="take-action-card">
+              <div class="call-to-action-text">Here are some ways you can take action now</div>
+              <ul class="follow-campaign-list">
+                <li>
+                  Follow
+                  <a href="https://www.homescampaignde.org/">H.O.M.E.S. Campaign</a>
+                </li>
+                <li>
+                  Send a letter to your local representative to support housing reform bills
+                  <a href="https://613b7d3b-0baa-4963-a0d2-2c365bc54f9e.filesusr.com/ugd/7148e3_2400e00b6b70477899b65e347060fdd6.docx?dn=Sample%20Letter%20for%20Bill%20of%20Rights%20for%20Individuals%20Experiencing%20Homelessness%20.docx">(Template by H.O.M.E.S.)</a>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>

--- a/app/explore_panel.R
+++ b/app/explore_panel.R
@@ -90,7 +90,8 @@ explore_panel <- tabPanel(
              households in a given cell.",
                                    tags$br(),
                                    downloadLink("downloadAll", "Download All Data"))
-                 )
+                 ),
+                 includeHTML("CTA.html")
         )
     )
 )

--- a/app/home_panel.r
+++ b/app/home_panel.r
@@ -108,26 +108,7 @@ home_panel <- tabPanel(
                       )
              )
     ),
-    tags$div(class = "main-point-container",
-             tags$div(class = "main-heading-container", 
-                      tags$div(class = "main-point",
-                               "Interested in doing something about the housing crisis in Delaware?"
-                      )
-             ),
-             tags$div(class = "take-action-container",
-                      tags$div(class = "take-action-card",
-                               tags$div(class = "call-to-action-text", 
-                                        "Here are some ways you can take action now"),
-                               tags$ul(class = "follow-campaign-list",
-                                       tags$li("Follow", tags$a("H.O.M.E.S. Campaign", href="https://www.homescampaignde.org/")),
-                                       tags$li("Send a letter to your local representative to support housing reform bills",
-                                               tags$a("(Template by H.O.M.E.S.)", 
-                                                      href = "https://613b7d3b-0baa-4963-a0d2-2c365bc54f9e.filesusr.com/ugd/7148e3_2400e00b6b70477899b65e347060fdd6.docx?dn=Sample%20Letter%20for%20Bill%20of%20Rights%20for%20Individuals%20Experiencing%20Homelessness%20.docx"),
-                                       )
-                               ),
-                      )
-             )
-    ),
+    includeHTML("CTA.html"), # Call-to-action section
     tags$div(
         id = "learn-more-container",
         class = "learn-more--container",


### PR DESCRIPTION
This PR adds a CTA to the explore page. The PR creates a separate HTML file for the CTA component and renders it to both the home page and the explore page. 

Fixes #238