### PR TITLE
Consistently label rent-burdened and severely rent-burdened groups

### DIFF
--- a/app/explore_panel.R
+++ b/app/explore_panel.R
@@ -59,6 +59,15 @@ explore_panel <- tabPanel(
                           )
 
                  ),
+                 tags$div(class = "bar-footnote-container",
+                          tags$span(class = "tooltip-span",
+                                    "What do \"rent-burdnened\" and \"severely rent-burdened\" mean?",
+                                    tags$span(class = "tooltip-text",
+                                              "Families spending more than 30% of their income on
+                                              rent are considered \"rent-burdened\". 
+                                              If they are spending more than 50%, they are considered as
+                                              \"severely rent-burdened\"."))
+                 ),
                  tags$div(class = "explore-description-container",
                           tags$div(class = "hbar-description-container",
                                    textOutput("h_bar_description"),

--- a/app/explore_panel.R
+++ b/app/explore_panel.R
@@ -74,11 +74,11 @@ explore_panel <- tabPanel(
                                    tags$span(class = "explore-select-input",
                                              selectInput("selectedCensusProp", 
                                                          label = NULL,
-                                                         choices = c("are spending 30% of their income on rent" = "30",
-                                                                     "are spending 50% of their income on rent" = "50",
-                                                                     "are receiving voucher" = "receiving_voucher"),
+                                                         choices = c("rent-burdened" = "30",
+                                                                     "severely rent-burdened" = "50",
+                                                                     "receiving voucher" = "receiving_voucher"),
                                                          selected = "30",
-                                                         width = 360))
+                                                         width = 250))
                           ),
                           textOutput("h_bar_last_sentence"),
                           ),

--- a/app/explore_panel.R
+++ b/app/explore_panel.R
@@ -65,7 +65,7 @@ explore_panel <- tabPanel(
                                     tags$span(class = "tooltip-text",
                                               "Families spending more than 30% of their income on
                                               rent are considered \"rent-burdened\". 
-                                              If they are spending more than 50%, they are considered as
+                                              If they are spending more than 50%, they are considered
                                               \"severely rent-burdened\"."))
                  ),
                  tags$div(class = "explore-description-container",

--- a/app/explore_panel.R
+++ b/app/explore_panel.R
@@ -61,7 +61,7 @@ explore_panel <- tabPanel(
                  ),
                  tags$div(class = "bar-footnote-container",
                           tags$span(class = "tooltip-span",
-                                    "What do \"rent-burdnened\" and \"severely rent-burdened\" mean?",
+                                    icon(name = "question-circle"), "What do \"rent-burdnened\" and \"severely rent-burdened\" mean?",
                                     tags$span(class = "tooltip-text",
                                               "Families spending more than 30% of their income on
                                               rent are considered \"rent-burdened\". 

--- a/app/scripts/plot_prop_census.R
+++ b/app/scripts/plot_prop_census.R
@@ -104,7 +104,8 @@ plot_prop_census <- function(perc, ids){
         scale_fill_manual("legend", values = c("1" = hex_selected,
                                                "0" = hex_default)) +
         scale_x_discrete(expand = expansion(mult = .1)) +
-        ylab(as.character(target_var))+
+        scale_y_continuous(labels = function(x) paste0(x, "%")) + 
+        ylab(str_to_title(burden_label))+
         xlab("")+
         theme(panel.background = element_rect(fill = "white"),
               legend.position = "none",

--- a/app/scripts/plot_table_desc.R
+++ b/app/scripts/plot_table_desc.R
@@ -35,9 +35,9 @@ to_plotly_data <- function(.data){
     return(.data)
 }
 
-recode_scheme <- c("receiving" = "Receiving Voucher",
-                   "spending_30" = "Spending 30%+ of income on rent",
-                   "spending_50" = "Spending 50%+ of income on rent")
+recode_scheme <- c("spending_30" = "Rent-burdened",
+                   "spending_50" = "Severely rent-burdened",
+                   "receiving" = "Receiving voucher")
 
 plot_table_desc <- function(agg_selected, is_selected){
     # Prepare a table for All Delaware
@@ -128,9 +128,7 @@ plot_table_desc <- function(agg_selected, is_selected){
                                 showline = FALSE,
                                 zeroline = FALSE,
                                 categoryorder = "array",
-                                categoryarray = rev(c("Spending 30%+ income on rent",
-                                                      "Spending 50%+ income on rent",
-                                                      "Receiving Vouchers"))),
+                                categoryarray = rev(c(recode_scheme))),
                    legend = list(traceorder = "reversed",
                                  orientation = 'h'),
                    margin = list(pad = 20)) %>% 

--- a/app/server.R
+++ b/app/server.R
@@ -318,7 +318,7 @@ shinyServer(function(input, output, session) {
         h_bar_pct_rounded <- h_bar_pct %>% round(1)
         # Render the description text 
         output$h_bar_description <- renderText({
-            str_glue("{h_bar_pct_rounded}% of families in {h_bar_region} ")
+            str_glue("{h_bar_pct_rounded}% of families in {h_bar_region} are ")
         })
     })
     

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -445,3 +445,37 @@
     max-width: 70rem;
     margin: auto;
 }
+
+.bar-footnote-container {
+    align-self: end;
+    color: grey;
+}
+
+
+/* Tooltips */
+
+.tooltip-span {
+  position: relative;
+  border-bottom: 1px dotted black;
+}
+
+.tooltip-span .tooltip-text {
+    visibility: hidden;
+  background-color: black;
+  color: #fff;
+  text-align: left;
+  border-radius: 6px;
+  padding: 5px 5px;
+  
+  /* Position the tooltip */
+  position: absolute;
+  z-index: 1;
+  bottom: 100%;
+  left: 10%;
+  margin-left: -60px;
+}
+
+.tooltip-span:hover .tooltip-text {
+  visibility: visible;
+}
+

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -159,7 +159,6 @@
     flex-direction: column;
     align-items: center;
     width: 100%;
-    margin-bottom: 4rem;
 }
 
 .explore-description-container {
@@ -407,6 +406,8 @@
     border-radius: 0;
     text-align: left;
     margin-top: 5px;
+    padding-right: 38px;
+    white-space: nowrap;
     
 }
 


### PR DESCRIPTION
This PR replaces the 30% vs. 50% labels with the "rent-burdened" vs. "severely rent-burdened" labels. Doing so makes the labels consistent across the app.

Fixes #252 