### PR TITLE
Remove horizontal whitespaces from the hero image

### DIFF
--- a/app/www/style.css
+++ b/app/www/style.css
@@ -497,4 +497,12 @@
 }
 
 
+/* Remove the x-paddings to show the hero image without borders */
+.container-fluid {
+    padding-right: 0;
+    padding-left: 0;
+    overflow: hidden;
+}
+
+
 


### PR DESCRIPTION
This PR removes horizontal whitespaces from the hero image, via removing x-paddings from the container.

Fixes #259 