### PR TITLE
Use fluidRow to remove x-paddings 

### DIFF
--- a/app/home_panel.r
+++ b/app/home_panel.r
@@ -4,7 +4,7 @@ source("counties.R")
 home_panel <- tabPanel(
     id = "home",
     title = "Home",
-    tags$div(class = "title-container",
+    fluidRow(class = "title-container",
              tags$div(class = "title",
                       "How is Delaware helping families in a housing crisis?"),
              actionLink(inputId = "to_explore_page", 
@@ -109,7 +109,7 @@ home_panel <- tabPanel(
              )
     ),
     includeHTML("CTA.html"), # Call-to-action section
-    tags$div(
+    fluidRow(
         id = "learn-more-container",
         class = "learn-more--container",
         tags$div(class = "main-point",

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -495,14 +495,3 @@
 .navbar-padding {
     width: 9em;
 }
-
-
-/* Remove the x-paddings to show the hero image without borders */
-.container-fluid {
-    padding-right: 0;
-    padding-left: 0;
-    overflow: hidden;
-}
-
-
-


### PR DESCRIPTION
This PR is an update to the previous PR #260.  I removed modifications to Bootstrap CSS. Instead, I used `fluidRow()` to be compatible with Bootstrap.

Fixes #259 